### PR TITLE
More CLAAS-3 improvements

### DIFF
--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -47,11 +47,11 @@ ANGLE_ATTRIBUTES = {
         'satazimuth': 'satellite azimuth angle degree clockwise from north',
     },
     'valid_range': {
-        'sunzenith': [0, 18000],
-        'satzenith': [0, 9000],
-        'azimuthdiff': [0, 18000],
-        'sunazimuth': [-18000, 18000],
-        'satazimuth': [-18000, 18000],
+        'sunzenith': np.array([0, 18000], dtype='int16'),
+        'satzenith': np.array([0, 9000], dtype='int16'),
+        'azimuthdiff': np.array([0, 18000], dtype='int16'),
+        'sunazimuth': np.array([-18000, 18000], dtype='int16'),
+        'satazimuth': np.array([-18000, 18000], dtype='int16'),
     },
     'mersi2_file_key':  {
         'sunzenith': 'Geolocation/SolarZenithAngle',

--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -110,6 +110,7 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
     """Get netcdf encoding for a datasets."""
     name = dataset.attrs['name']
     id_tag = dataset.attrs.get('id_tag', None)
+    enc = {}
     if id_tag is not None:
         if id_tag.startswith('ch_tb'):
             # IR channel
@@ -119,7 +120,7 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
                    'zlib': True,
                    'complevel': 4,
                    'add_offset': 273.15}
-        if id_tag.startswith('ch_r'):
+        elif id_tag.startswith('ch_r'):
             # Refl channel
             enc = {'dtype': 'int16',
                    'scale_factor': 0.01,
@@ -127,7 +128,7 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
                    'complevel': 4,
                    '_FillValue': -32767,
                    'add_offset': 0.0}
-        if id_tag in PPS_ANGLE_TAGS:
+        elif id_tag in PPS_ANGLE_TAGS:
             # Angle
             enc = {
                 'dtype': 'int16',

--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -139,7 +139,7 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
                 'add_offset': 0.0}
         if chunks is not None:
             enc['chunksizes'] = chunks
-    elif name in ['lon', 'lat']:
+    if name in ['lon', 'lat']:
         # Lat/Lon
         enc = {'dtype': 'float32',
                'zlib': True,
@@ -155,7 +155,7 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
         # pygac scanline_timestamps
         enc = {'dtype': 'int64', 'zlib': True,
                'complevel': 4, '_FillValue': -1.0}
-    else:
+    if not enc:
         raise ValueError('Unsupported band: {}'.format(name))
     return name, enc
 

--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -97,7 +97,11 @@ def get_encoding(scene, bandnames, pps_tagnames, chunks=None):
     """Get netcdf encoding for all datasets."""
     encoding = {}
     for dataset in scene.keys():
-        name, enc = get_band_encoding(scene[dataset.name], bandnames, pps_tagnames, chunks=chunks)
+        try:
+            name, enc = get_band_encoding(scene[dataset.name], bandnames, pps_tagnames,
+                                          chunks=chunks)
+        except ValueError:
+            continue
         encoding[name] = enc
     return encoding
 
@@ -134,7 +138,7 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
                 'add_offset': 0.0}
         if chunks is not None:
             enc['chunksizes'] = chunks
-    if name in ['lon', 'lat']:
+    elif name in ['lon', 'lat']:
         # Lat/Lon
         enc = {'dtype': 'float32',
                'zlib': True,
@@ -142,14 +146,16 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
                '_FillValue': -999.0}
         if chunks is not None:
             enc['chunksizes'] = (chunks[1], chunks[2])
-    if name in ['qual_flags']:
+    elif name in ['qual_flags']:
         # pygac qual flags
         enc = {'dtype': 'int16', 'zlib': True,
                'complevel': 4, '_FillValue': -32001.0}
-    if name in ['scanline_timestamps']:
+    elif name in ['scanline_timestamps']:
         # pygac scanline_timestamps
         enc = {'dtype': 'int64', 'zlib': True,
                'complevel': 4, '_FillValue': -1.0}
+    else:
+        raise ValueError('Unsupported band: {}'.format(name))
     return name, enc
 
 

--- a/level1c4pps/gac2pps_lib.py
+++ b/level1c4pps/gac2pps_lib.py
@@ -87,7 +87,7 @@ def update_ancilliary_datasets(scene):
     first_jan_1970 = np.array([datetime(1970, 1, 1, 0, 0, 0)]).astype('datetime64[ns]')
     scanline_timestamps = np.array(scene['qual_flags'].coords['acq_time'] -
                                    first_jan_1970).astype(dtype='timedelta64[ms]').astype(np.float64)
-    scene['scanline_timestamps'] = xr.DataArray(da.from_array(scanline_timestamps),
+    scene['scanline_timestamps'] = xr.DataArray(da.from_array(scanline_timestamps, chunks=1024),
                                                 dims=['y'], coords={'y': scene['qual_flags']['y']})
     scene['scanline_timestamps'].attrs['units'] = 'Milliseconds since 1970-01-01 00:00:00 UTC'
 

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -246,7 +246,7 @@ def add_ancillary_datasets(scene, lons, lats, sunz, satz, azidiff,
         lats: Latitude coordinates
         sunz: Solar zenith angle
         satz: Satellite zenith angle
-        azidiff: Absoulte azimuth difference angle
+        azidiff: Absolute azimuth difference angle
         chunks: Chunksize
 
     """
@@ -299,10 +299,23 @@ def get_encoding_seviri(scene):
     """Get netcdf encoding for all datasets."""
     # Bands
     chunks = (1, 512, 3712)
-    return get_encoding(scene,
-                        bandnames=BANDNAMES,
-                        pps_tagnames=PPS_TAGNAMES,
-                        chunks=chunks)
+    encoding = get_encoding(scene,
+                            bandnames=BANDNAMES,
+                            pps_tagnames=PPS_TAGNAMES,
+                            chunks=chunks)
+
+    # Time
+    acq_units = scene.attrs['start_time'].strftime(
+        'milliseconds since %Y-%m-%d %H:%M')
+    encoding['acq_time'] = {'units': acq_units,
+                            'calendar': 'standard',
+                            '_FillValue': -9999.0}
+    encoding['time'] = {'units': 'days since 2004-01-01 00:00',
+                        'calendar': 'standard',
+                        '_FillValue': None,
+                        'chunksizes': [1]}
+
+    return encoding
 
 
 def get_header_attrs(scene):

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -381,6 +381,7 @@ def process_one_scan(tslot_files, out_path, rotate=True):
                        header_attrs=get_header_attrs(scn_),
                        engine='netcdf4',
                        encoding=get_encoding_seviri(scn_),
+                       unlimited_dims=['time'],
                        include_lonlats=False,
                        pretty=True,
                        flatten_attrs=True,

--- a/level1c4pps/tests/test_angles.py
+++ b/level1c4pps/tests/test_angles.py
@@ -106,7 +106,8 @@ class TestUpdateAnglesAttribute(unittest.TestCase):
         update_angle_attributes(angle_dict, band)
         self.assertEqual(angle_dict['satzenith'].attrs['name'], 'satzenith')
         self.assertEqual(angle_dict['satzenith'].attrs['id_tag'], 'satzenith')
-        self.assertEqual(angle_dict['satzenith'].attrs['valid_range'], [0, 9000])
+        np.testing.assert_array_equal(angle_dict['satzenith'].attrs['valid_range'],
+                                      np.array([0, 9000], dtype='int16'))
         self.assertNotIn('area', angle_dict['satzenith'].attrs.keys())
         self.assertIn('time', angle_dict['satzenith'].coords.keys())
         self.assertIn('long_name', angle_dict['satzenith'].attrs.keys())

--- a/level1c4pps/tests/test_gac2pps.py
+++ b/level1c4pps/tests/test_gac2pps.py
@@ -46,7 +46,8 @@ class TestGac2PPS(unittest.TestCase):
                                        'id_tag': 'ch_tb11',
                                        'platform_name': 'tirosn',
                                        'orbit_number': 99999})
-        qual_f = mock.MagicMock(attrs={'name': 'qual_flags'})
+        qual_f = mock.MagicMock(attrs={'name': 'qual_flags',
+                                       'id_tag': 'qual_flags'})
         scan_t = mock.MagicMock(attrs={'name': 'scanline_timestamps'})
         self.scene = Scene()
         scene_dict = {'1': vis006, '4': ir_108, 'qual_flags': qual_f, 'scanline_timestamps': scan_t}

--- a/level1c4pps/tests/test_init.py
+++ b/level1c4pps/tests/test_init.py
@@ -16,29 +16,27 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with level1c4pps.  If not, see <http://www.gnu.org/licenses/>.
-# Author(s):
-
-#   Nina Hakansson <nina.hakansson@smhi.se>
-
-"""Test Initializer for level1c4pps."""
 
 import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+import xarray as xr
 
-from level1c4pps.tests import (test_angles, test_seviri2pps, test_gac2pps,
-                               test_mersi22pps, test_init)
+import level1c4pps
+
+
+class TestInit(unittest.TestCase):
+    def test_get_band_encoding(self):
+        ds = xr.DataArray([], attrs={'name': 'dummy'})
+        self.assertRaises(ValueError, level1c4pps.get_band_encoding, ds,
+                          None, None)
 
 
 def suite():
-    """Test global test suite."""
+    """Create the test suite for test_init."""
+    loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
-    mysuite.addTests(test_angles.suite())
-    mysuite.addTests(test_seviri2pps.suite())
-    mysuite.addTests(test_gac2pps.suite())
-    mysuite.addTests(test_mersi22pps.suite())
-    mysuite.addTests(test_init.suite())
+    mysuite.addTest(loader.loadTestsFromTestCase(TestInit))
     return mysuite
-
-
-def load_tests(loader, tests, pattern):
-    """Load all tests."""
-    return suite()

--- a/level1c4pps/tests/test_init.py
+++ b/level1c4pps/tests/test_init.py
@@ -18,10 +18,6 @@
 # along with level1c4pps.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 import xarray as xr
 
 import level1c4pps

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -323,6 +323,7 @@ class TestSeviri2PPS(unittest.TestCase):
         azimuthdiff = mock.MagicMock(attrs={'name': 'image13',
                                             'id_tag': 'azimuthdiff'})
         scene = Scene()
+        scene.attrs = {'start_time': dt.datetime(2009, 7, 1, 12, 15)}
         scene_dict = {'VIS006': vis006, 'IR_108': ir_108, 'lat': lat, 'lon': lon,
                       'sunzenith': sunzenith, 'satzenith': satzenith,  'azimuthdiff': azimuthdiff}
         for key in scene_dict:
@@ -342,6 +343,13 @@ class TestSeviri2PPS(unittest.TestCase):
                           'complevel': 4,
                           '_FillValue': -999.0,
                           'chunksizes': (512, 3712)}
+        enc_exp_time = {'units': 'days since 2004-01-01 00:00',
+                        'calendar': 'standard',
+                        '_FillValue': None,
+                        'chunksizes': [1]}
+        enc_exp_acq = {'units': 'milliseconds since 2009-07-01 12:15',
+                       'calendar': 'standard',
+                       '_FillValue': -9999.0}
         encoding_exp = {
             'image0': {'dtype': 'int16',
                        'scale_factor': 0.01,
@@ -361,7 +369,9 @@ class TestSeviri2PPS(unittest.TestCase):
             'image12': enc_exp_angles,
             'image13': enc_exp_angles,
             'lon': enc_exp_coords,
-            'lat': enc_exp_coords
+            'lat': enc_exp_coords,
+            'time': enc_exp_time,
+            'acq_time': enc_exp_acq
         }
         encoding = seviri2pps.get_encoding_seviri(scene)
         self.assertDictEqual(encoding, encoding_exp)


### PR DESCRIPTION
Based on feedback from Jan-Fokke.

Here is an example ncdump:

<details>

```
netcdf S_NWC_seviri_meteosat9_99999_20090701T1200000Z_20090701T1215000Z {
dimensions:
        time = UNLIMITED ; // (1 currently)
        x = 3712 ;
        y = 3712 ;
        corners = 4 ;
        bnds_1d = 2 ;
variables:
        double time(time) ;
                time:bounds = "time_bnds" ;
                time:standard_name = "time" ;
                time:units = "days since 2004-01-01" ;
                time:calendar = "standard" ;
        double x(x) ;
                x:standard_name = "projection_x_coordinate" ;
                x:units = "m" ;
        double y(y) ;
                y:standard_name = "projection_y_coordinate" ;
                y:units = "m" ;
        float lon(y, x) ;
                lon:_FillValue = -999.f ;
                lon:end_time = "2009-07-01 12:12:40.964000" ;
                lon:long_name = "longitude coordinate" ;
                lon:modifiers = "" ;
                lon:standard_name = "longitude" ;
                lon:start_time = "2009-07-01 12:00:10.021000" ;
                lon:units = "degrees_east" ;
        float lat(y, x) ;
                lat:_FillValue = -999.f ;
                lat:end_time = "2009-07-01 12:12:40.964000" ;
                lat:long_name = "latitude coordinate" ;
                lat:modifiers = "" ;
                lat:standard_name = "latitude" ;
                lat:start_time = "2009-07-01 12:00:10.021000" ;
                lat:units = "degrees_north" ;
        double acq_time(y) ;
                acq_time:_FillValue = -9999. ;
                acq_time:units = "milliseconds since 2009-07-01T12:00:00" ;
                acq_time:calendar = "standard" ;
        short azimuthdiff(time, y, x) ;
                azimuthdiff:_FillValue = -32767s ;
                azimuthdiff:end_time = "2009-07-01 12:12:40.964000" ;
                azimuthdiff:id_tag = "azimuthdiff" ;
                azimuthdiff:long_name = "absolute azimuth difference angle" ;
                azimuthdiff:modifiers = "" ;
                azimuthdiff:standard_name = "absolute_angle_of_rotation_from_solar_azimuth_to_platform_azimuth" ;
                azimuthdiff:start_time = "2009-07-01 12:00:10.021000" ;
                azimuthdiff:units = "degree" ;
                azimuthdiff:valid_range = 0LL, 18000LL ;
                azimuthdiff:coordinates = "acq_time lat lon" ;
                azimuthdiff:add_offset = 0. ;
                azimuthdiff:scale_factor = 0.01 ;
        byte georef_offset_corrected(time) ;
                georef_offset_corrected:comment = "Until December 2017, SEVIRI L1.5 data is shifted by 1.5km SSP North and West against the nominal GEOS projection. Since December 2017 this offset has been corrected by EUMETSAT. This flag indicates if the correction has been applied. If not, the area extent is adjusted so that the projection always matches the data." ;
                georef_offset_corrected:flag_meanings = "georef_offset_present georef_offset_corrected" ;
                georef_offset_corrected:flag_values = 0b, 1b ;
                georef_offset_corrected:long_name = "Georeferencing offset correction flag" ;
                georef_offset_corrected:modifiers = "" ;
        short image0(time, y, x) ;
                image0:_FillValue = -32767s ;
                image0:calibration = "reflectance" ;
                image0:description = "SEVIRI VIS006" ;
                image0:end_time = "2009-07-01 12:12:40.964000" ;
                image0:id_tag = "ch_r06" ;
                image0:long_name = "image0" ;
                image0:modifiers = "" ;
                image0:resolution = 3000.403165817 ;
                image0:standard_name = "toa_bidirectional_reflectance" ;
                image0:start_time = "2009-07-01 12:00:10.021000" ;
                image0:sun_earth_distance_correction_applied = "false" ;
                image0:sun_earth_distance_correction_factor = 1. ;
                image0:sun_zenith_angle_correction_applied = "false" ;
                image0:units = "%" ;
                image0:wavelength = 0.56, 0.635, 0.71 ;
                image0:coordinates = "acq_time lat lon" ;
                image0:add_offset = 0. ;
                image0:scale_factor = 0.01 ;
        short image1(time, y, x) ;
                image1:_FillValue = -32767s ;
                image1:calibration = "reflectance" ;
                image1:description = "SEVIRI VIS008" ;
                image1:end_time = "2009-07-01 12:12:40.964000" ;
                image1:id_tag = "ch_r09" ;
                image1:long_name = "image1" ;
                image1:modifiers = "" ;
                image1:resolution = 3000.403165817 ;
                image1:standard_name = "toa_bidirectional_reflectance" ;
                image1:start_time = "2009-07-01 12:00:10.021000" ;
                image1:sun_earth_distance_correction_applied = "false" ;
                image1:sun_earth_distance_correction_factor = 1. ;
                image1:sun_zenith_angle_correction_applied = "false" ;
                image1:units = "%" ;
                image1:wavelength = 0.74, 0.81, 0.88 ;
                image1:coordinates = "acq_time lat lon" ;
                image1:add_offset = 0. ;
                image1:scale_factor = 0.01 ;
        short image10(time, y, x) ;
                image10:_FillValue = -32767s ;
                image10:calibration = "brightness_temperature" ;
                image10:description = "SEVIRI WV_073" ;
                image10:end_time = "2009-07-01 12:12:40.964000" ;
                image10:id_tag = "ch_tb73" ;
                image10:long_name = "image10" ;
                image10:modifiers = "" ;
                image10:resolution = 3000.403165817 ;
                image10:standard_name = "brightness_temperature" ;
                image10:start_time = "2009-07-01 12:00:10.021000" ;
                image10:sun_earth_distance_correction_applied = "false" ;
                image10:sun_earth_distance_correction_factor = 1. ;
                image10:sun_zenith_angle_correction_applied = "false" ;
                image10:units = "K" ;
                image10:wavelength = 6.85, 7.35, 7.85 ;
                image10:coordinates = "acq_time lat lon" ;
                image10:add_offset = 273.15 ;
                image10:scale_factor = 0.01 ;
        short image2(time, y, x) ;
                image2:_FillValue = -32767s ;
                image2:calibration = "reflectance" ;
                image2:description = "SEVIRI IR_016" ;
                image2:end_time = "2009-07-01 12:12:40.964000" ;
                image2:id_tag = "ch_r16" ;
                image2:long_name = "image2" ;
                image2:modifiers = "" ;
                image2:resolution = 3000.403165817 ;
                image2:standard_name = "reflectance" ;
                image2:start_time = "2009-07-01 12:00:10.021000" ;
                image2:sun_earth_distance_correction_applied = "false" ;
                image2:sun_earth_distance_correction_factor = 1. ;
                image2:sun_zenith_angle_correction_applied = "false" ;
                image2:units = "%" ;
                image2:wavelength = 1.5, 1.64, 1.78 ;
                image2:coordinates = "acq_time lat lon" ;
                image2:add_offset = 0. ;
                image2:scale_factor = 0.01 ;
        short image3(time, y, x) ;
                image3:_FillValue = -32767s ;
                image3:calibration = "brightness_temperature" ;
                image3:description = "SEVIRI IR_039" ;
                image3:end_time = "2009-07-01 12:12:40.964000" ;
                image3:id_tag = "ch_tb37" ;
                image3:long_name = "image3" ;
                image3:modifiers = "" ;
                image3:resolution = 3000.403165817 ;
                image3:standard_name = "brightness_temperature" ;
                image3:start_time = "2009-07-01 12:00:10.021000" ;
                image3:sun_earth_distance_correction_applied = "false" ;
                image3:sun_earth_distance_correction_factor = 1. ;
                image3:sun_zenith_angle_correction_applied = "false" ;
                image3:units = "K" ;
                image3:wavelength = 3.48, 3.92, 4.36 ;
                image3:coordinates = "acq_time lat lon" ;
                image3:add_offset = 273.15 ;
                image3:scale_factor = 0.01 ;
        short image4(time, y, x) ;
                image4:_FillValue = -32767s ;
                image4:calibration = "brightness_temperature" ;
                image4:description = "SEVIRI IR_087" ;
                image4:end_time = "2009-07-01 12:12:40.964000" ;
                image4:id_tag = "ch_tb85" ;
                image4:long_name = "image4" ;
                image4:modifiers = "" ;
                image4:resolution = 3000.403165817 ;
                image4:standard_name = "brightness_temperature" ;
                image4:start_time = "2009-07-01 12:00:10.021000" ;
                image4:sun_earth_distance_correction_applied = "false" ;
                image4:sun_earth_distance_correction_factor = 1. ;
                image4:sun_zenith_angle_correction_applied = "false" ;
                image4:units = "K" ;
                image4:wavelength = 8.3, 8.7, 9.1 ;
                image4:coordinates = "acq_time lat lon" ;
                image4:add_offset = 273.15 ;
                image4:scale_factor = 0.01 ;
        short image5(time, y, x) ;
                image5:_FillValue = -32767s ;
                image5:calibration = "brightness_temperature" ;
                image5:description = "SEVIRI IR_108" ;
                image5:end_time = "2009-07-01 12:12:40.964000" ;
                image5:id_tag = "ch_tb11" ;
                image5:long_name = "image5" ;
                image5:modifiers = "" ;
                image5:resolution = 3000.403165817 ;
                image5:standard_name = "brightness_temperature" ;
                image5:start_time = "2009-07-01 12:00:10.021000" ;
                image5:sun_earth_distance_correction_applied = "false" ;
                image5:sun_earth_distance_correction_factor = 1. ;
                image5:sun_zenith_angle_correction_applied = "false" ;
                image5:units = "K" ;
                image5:wavelength = 9.8, 10.8, 11.8 ;
                image5:coordinates = "acq_time lat lon" ;
                image5:add_offset = 273.15 ;
                image5:scale_factor = 0.01 ;
        short image6(time, y, x) ;
                image6:_FillValue = -32767s ;
                image6:calibration = "brightness_temperature" ;
                image6:description = "SEVIRI IR_120" ;
                image6:end_time = "2009-07-01 12:12:40.964000" ;
                image6:id_tag = "ch_tb12" ;
                image6:long_name = "image6" ;
                image6:modifiers = "" ;
                image6:resolution = 3000.403165817 ;
                image6:standard_name = "brightness_temperature" ;
                image6:start_time = "2009-07-01 12:00:10.021000" ;
                image6:sun_earth_distance_correction_applied = "false" ;
                image6:sun_earth_distance_correction_factor = 1. ;
                image6:sun_zenith_angle_correction_applied = "false" ;
                image6:units = "K" ;
                image6:wavelength = 11., 12., 13. ;
                image6:coordinates = "acq_time lat lon" ;
                image6:add_offset = 273.15 ;
                image6:scale_factor = 0.01 ;
        short image7(time, y, x) ;
                image7:_FillValue = -32767s ;
                image7:calibration = "brightness_temperature" ;
                image7:description = "SEVIRI IR_134" ;
                image7:end_time = "2009-07-01 12:12:40.964000" ;
                image7:id_tag = "ch_tb133" ;
                image7:long_name = "image7" ;
                image7:modifiers = "" ;
                image7:resolution = 3000.403165817 ;
                image7:standard_name = "brightness_temperature" ;
                image7:start_time = "2009-07-01 12:00:10.021000" ;
                image7:sun_earth_distance_correction_applied = "false" ;
                image7:sun_earth_distance_correction_factor = 1. ;
                image7:sun_zenith_angle_correction_applied = "false" ;
                image7:units = "K" ;
                image7:wavelength = 12.4, 13.4, 14.4 ;
                image7:coordinates = "acq_time lat lon" ;
                image7:add_offset = 273.15 ;
                image7:scale_factor = 0.01 ;
        short image8(time, y, x) ;
                image8:_FillValue = -32767s ;
                image8:calibration = "brightness_temperature" ;
                image8:description = "SEVIRI IR_097" ;
                image8:end_time = "2009-07-01 12:12:40.964000" ;
                image8:id_tag = "ch_tb97" ;
                image8:long_name = "image8" ;
                image8:modifiers = "" ;
                image8:resolution = 3000.403165817 ;
                image8:standard_name = "brightness_temperature" ;
                image8:start_time = "2009-07-01 12:00:10.021000" ;
                image8:sun_earth_distance_correction_applied = "false" ;
                image8:sun_earth_distance_correction_factor = 1. ;
                image8:sun_zenith_angle_correction_applied = "false" ;
                image8:units = "K" ;
                image8:wavelength = 9.38, 9.66, 9.94 ;
                image8:coordinates = "acq_time lat lon" ;
                image8:add_offset = 273.15 ;
                image8:scale_factor = 0.01 ;
        short image9(time, y, x) ;
                image9:_FillValue = -32767s ;
                image9:calibration = "brightness_temperature" ;
                image9:description = "SEVIRI WV_062" ;
                image9:end_time = "2009-07-01 12:12:40.964000" ;
                image9:id_tag = "ch_tb67" ;
                image9:long_name = "image9" ;
                image9:modifiers = "" ;
                image9:resolution = 3000.403165817 ;
                image9:standard_name = "brightness_temperature" ;
                image9:start_time = "2009-07-01 12:00:10.021000" ;
                image9:sun_earth_distance_correction_applied = "false" ;
                image9:sun_earth_distance_correction_factor = 1. ;
                image9:sun_zenith_angle_correction_applied = "false" ;
                image9:units = "K" ;
                image9:wavelength = 5.35, 6.25, 7.15 ;
                image9:coordinates = "acq_time lat lon" ;
                image9:add_offset = 273.15 ;
                image9:scale_factor = 0.01 ;
        double projection_area_extent(time, corners) ;
                projection_area_extent:_FillValue = NaN ;
                projection_area_extent:comment = "Area extent (lower left x, lower left y, upper right x, upper right y) in projection coordinates" ;
                projection_area_extent:long_name = "Projection area extent" ;
                projection_area_extent:modifiers = "" ;
                projection_area_extent:units = "meters" ;
        double satellite_altitude(time) ;
                satellite_altitude:_FillValue = NaN ;
                satellite_altitude:comment = "Relative and perpendicular to the surface of the earth ellipsoid. Not to be confused with projection altitude." ;
                satellite_altitude:long_name = "Actual satellite altitude" ;
                satellite_altitude:modifiers = "" ;
                satellite_altitude:units = "meters" ;
        double satellite_latitude(time) ;
                satellite_latitude:_FillValue = NaN ;
                satellite_latitude:comment = "Not to be confused with projection latitude" ;
                satellite_latitude:long_name = "Actual satellite latitude" ;
                satellite_latitude:modifiers = "" ;
                satellite_latitude:units = "degree_north" ;
        double satellite_longitude(time) ;
                satellite_longitude:_FillValue = NaN ;
                satellite_longitude:comment = "Not to be confused with projection longitude" ;
                satellite_longitude:long_name = "Actual satellite longitude" ;
                satellite_longitude:modifiers = "" ;
                satellite_longitude:units = "degree_east" ;
        short satzenith(time, y, x) ;
                satzenith:_FillValue = -32767s ;
                satzenith:end_time = "2009-07-01 12:12:40.964000" ;
                satzenith:id_tag = "satzenith" ;
                satzenith:long_name = "satellite zenith angle" ;
                satzenith:modifiers = "" ;
                satzenith:standard_name = "sensor_zenith_angle" ;
                satzenith:start_time = "2009-07-01 12:00:10.021000" ;
                satzenith:units = "degree" ;
                satzenith:valid_range = 0LL, 9000LL ;
                satzenith:coordinates = "acq_time lat lon" ;
                satzenith:add_offset = 0. ;
                satzenith:scale_factor = 0.01 ;
        short sunzenith(time, y, x) ;
                sunzenith:_FillValue = -32767s ;
                sunzenith:end_time = "2009-07-01 12:12:40.964000" ;
                sunzenith:id_tag = "sunzenith" ;
                sunzenith:long_name = "sun zenith angle" ;
                sunzenith:modifiers = "" ;
                sunzenith:standard_name = "solar_zenith_angle" ;
                sunzenith:start_time = "2009-07-01 12:00:10.021000" ;
                sunzenith:units = "degree" ;
                sunzenith:valid_range = 0LL, 18000LL ;
                sunzenith:coordinates = "acq_time lat lon" ;
                sunzenith:add_offset = 0. ;
                sunzenith:scale_factor = 0.01 ;
        double time_bnds(time, bnds_1d) ;
                time_bnds:units = "days since 2004-01-01" ;
                time_bnds:calendar = "standard" ;

// global attributes:
                :date_created = "2019-11-25T17:50:17Z" ;
                :end_time = "2009-07-01 12:15:00" ;
                :image_rotated = "true" ;
                :instrument = "SEVIRI" ;
                :orbit_number = "99999" ;
                :platform = "Meteosat-9" ;
                :projection = "geos" ;
                :projection_altitude = 35785831. ;
                :projection_latitude = 0. ;
                :projection_longitude = 0.f ;
                :projection_semi_major_axis = 6378169. ;
                :projection_semi_minor_axis = 6356583.8 ;
                :source = "seviri2pps.py" ;
                :start_time = "2009-07-01 12:00:00" ;
                :history = "Created by pytroll/satpy on 2019-11-25 17:50:17.076401" ;
                :Conventions = "CF-1.7" ;
```

</details>

This should contain everything we need for CLAAS level 2 products. @ninahakansson Can we tell PPS to  transfer selected global attributes and variables to its output? Otherwise no problem, we can add a post-processing step for that.

- [X] Improve time encoding in seviri2pps
- [x] Store non-static metadata in nc variables

Depends on https://github.com/pytroll/satpy/pull/976