### PR TITLE
Fix orbit_number attribute

### DIFF
--- a/level1c4pps/gac2pps_lib.py
+++ b/level1c4pps/gac2pps_lib.py
@@ -119,7 +119,7 @@ def set_header_and_band_attrs(scene):
     irch = scene['4']
     scene.attrs['platform'] = irch.attrs['platform_name']
     scene.attrs['platform_name'] = irch.attrs['platform_name']
-    scene.attrs['orbit_number'] = '{:05d}'.format(irch.attrs['orbit_number'])
+    scene.attrs['orbit_number'] = irch.attrs['orbit_number']
     scene.attrs['orbit'] = scene.attrs['orbit_number']
 
     # bands

--- a/level1c4pps/mersi22pps_lib.py
+++ b/level1c4pps/mersi22pps_lib.py
@@ -96,7 +96,7 @@ def set_header_and_band_attrs(scene):
     scene.attrs['source'] = "mersi22pps.py"
     # Perhaps one can get the orbit number from the hdf file?
     # FIXME!
-    scene.attrs['orbit_number'] = "99999"
+    scene.attrs['orbit_number'] = 99999
     nowutc = datetime.utcnow()
     scene.attrs['date_created'] = nowutc.strftime("%Y-%m-%dT%H:%M:%SZ")
 

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -178,7 +178,7 @@ def set_attrs(scene):
     scene.attrs['platform'] = scene['IR_108'].attrs['platform_name']
     scene.attrs['instrument'] = 'SEVIRI'
     scene.attrs['source'] = "seviri2pps.py"
-    scene.attrs['orbit_number'] = "99999"
+    scene.attrs['orbit_number'] = 99999
     nowutc = datetime.utcnow()
     scene.attrs['date_created'] = nowutc.strftime("%Y-%m-%dT%H:%M:%SZ")
 

--- a/level1c4pps/tests/test_mersi22pps.py
+++ b/level1c4pps/tests/test_mersi22pps.py
@@ -102,6 +102,7 @@ class TestMersi22PPS(unittest.TestCase):
     def test_set_header_and_band_attrs(self):
         """Test to set header_and_band_attrs."""
         mersi22pps.set_header_and_band_attrs(self.scene)
+        self.assertTrue(isinstance(self.scene.attrs['orbit_number'], int))
 
 
 def suite():


### PR DESCRIPTION
Changed attribute orbit number to integer.

In some situations (python2) when reading from C PPS count on orbit_number being an integer.

The error message is:
TypeError: an integer is required

In later versions of PPS, the problem might be fixed.
For python3 things usually work anyway.