### PR TITLE
Fix problem with b missing in proj_dict

### DIFF
--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -297,10 +297,19 @@ def add_proj_satpos(scene):
     orb = scene['IR_108'].attrs['orbital_parameters']
 
     # Area extent
+    try:
+        # Traditionally a, b was included in proj_dict
+        param_a = scene.attrs['area'].proj_dict['a']
+        param_b = scene.attrs['area'].proj_dict['b']
+    except KeyError:
+        # But sometimes b is missing:
+        from pyresample.utils import proj4_radius_parameters
+        param_a, param_b = proj4_radius_parameters(scene.attrs['area'].proj_dict)
+
     scene.attrs.update({
         'projection': 'geos',
-        'projection_semi_major_axis': scene.attrs['area'].proj_dict['a'],
-        'projection_semi_minor_axis': scene.attrs['area'].proj_dict['b'],
+        'projection_semi_major_axis': param_a,
+        'projection_semi_minor_axis': param_b,
         'projection_longitude': orb['projection_longitude'],
         'projection_latitude': orb['projection_latitude'],
         'projection_altitude': orb['projection_altitude']

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -303,8 +303,8 @@ def add_proj_satpos(scene):
         param_b = scene.attrs['area'].proj_dict['b']
     except KeyError:
         # But sometimes b is missing:
-        from pyresample.utils import proj4_radius_parameters
-        param_a, param_b = proj4_radius_parameters(scene.attrs['area'].proj_dict)
+        param_a = scene.attrs['area'].crs.ellipsoid.semi_major_metre
+        param_b = scene.attrs['area'].crs.ellipsoid.semi_minor_metre
 
     scene.attrs.update({
         'projection': 'geos',


### PR DESCRIPTION
For newer version of proj 'b' is not always included in the proj_dict attribute in the
satpy scene['area'] object. Use proj4_radius_parameters from pyresample utils to 
find it when it is missing. 