### PR TITLE
Get tle_dir and tle_name from PYGAC config file.

### DIFF
--- a/bin/gac2pps.py
+++ b/bin/gac2pps.py
@@ -52,9 +52,16 @@ if __name__ == "__main__":
     parser.add_argument('-el', '--end_line', type=int, nargs='?',
                         required=False, default=None,
                         help="Use only part of data, start with end_line.")
-
+    parser.add_argument('-td', '--tle_dir', type=str, nargs='?',
+                        required=False, default='.',
+                        help="TLE directory.")
+    parser.add_argument('-tn', '--tle_name', type=str, nargs='?',
+                        required=False, default='.',
+                        help="TLE_name.")
     options = parser.parse_args()
     process_one_file(options.file, options.out_dir,
                      reader_kwargs={'start_line': options.start_line,
                                     'end_line': options.end_line,
+                                    'tle_name': options.tle_name,
+                                    'tle_dir': options.tle_dir,
                                     'strip_invalid_coords': not options.dont_strip_invalid_coords})

--- a/level1c4pps/gac2pps_lib.py
+++ b/level1c4pps/gac2pps_lib.py
@@ -117,10 +117,19 @@ def set_header_and_band_attrs(scene):
             scene[band].attrs['sun_earth_distance_correction_applied'] = 'True'
     return nimg
 
-
 def process_one_file(gac_file, out_path='.', reader_kwargs=None):
     """Make level 1c files in PPS-format."""
     tic = time.time()
+    if reader_kwargs is None:
+        reader_kwargs = {}
+    if 'tle_dir' not in reader_kwargs:
+        from pygac.configuration import get_config
+        conf = get_config()
+        tle_dir = conf.get('tle', 'tledir', raw=True)
+        tle_name = conf.get('tle', 'tlename', raw=True)
+        reader_kwargs['tle_dir'] = tle_dir
+        reader_kwargs['tle_name'] = tle_name
+ 
     scn_ = Scene(reader='avhrr_l1b_gaclac',
                  filenames=[gac_file], reader_kwargs=reader_kwargs)
 

--- a/level1c4pps/gac2pps_lib.py
+++ b/level1c4pps/gac2pps_lib.py
@@ -117,6 +117,7 @@ def set_header_and_band_attrs(scene):
             scene[band].attrs['sun_earth_distance_correction_applied'] = 'True'
     return nimg
 
+
 def process_one_file(gac_file, out_path='.', reader_kwargs=None):
     """Make level 1c files in PPS-format."""
     tic = time.time()
@@ -129,7 +130,7 @@ def process_one_file(gac_file, out_path='.', reader_kwargs=None):
         tle_name = conf.get('tle', 'tlename', raw=True)
         reader_kwargs['tle_dir'] = tle_dir
         reader_kwargs['tle_name'] = tle_name
- 
+
     scn_ = Scene(reader='avhrr_l1b_gaclac',
                  filenames=[gac_file], reader_kwargs=reader_kwargs)
 


### PR DESCRIPTION
Allow tle_dir and tle_name to be specified on command line and when
missing read PYGAC_CONFIG_FILE.
Satpy is not using PYGAC_CONFIG_FILE any longer.
In future consider create level1c4pps config file instead.
But pygac allowes tle_name to be formated in a specific but generic way (TLE_%(satname)s.txt).
Maybe best to keep this inside pygac?

The unittest fails with version of pygac > 1.3.0. As the cropped GAC file can no longer be read.