### PR TITLE
Get rid of extra variables showing up in level1c file

### DIFF
--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -209,10 +209,16 @@ def rename_latitude_longitude(scene):
         lat_name_satpy = 'lat_pixels'
     if 'lon_pixels' in scene:
         lon_name_satpy = 'lon_pixels'
+
+    scene[lat_name_satpy].rename('lat')
+    scene[lon_name_satpy].rename('lon')
+    scene[lat_name_satpy].attrs['name'] = 'lat'
+    scene[lon_name_satpy].attrs['name'] = 'lon'
     scene['lat'] = scene[lat_name_satpy]
     scene['lon'] = scene[lon_name_satpy]
     del scene[lat_name_satpy]
     del scene[lon_name_satpy]
+
     # Update attributes
     scene['lat'].attrs['long_name'] = 'latitude coordinate'
     scene['lon'].attrs['long_name'] = 'longitude coordinate'
@@ -228,11 +234,14 @@ def rename_latitude_longitude(scene):
             del scene['lon'].attrs[attr]
         except KeyError:
             pass
-    try:
-        del scene['lat'].coords['acq_time']
-        del scene['lon'].coords['acq_time']
-    except KeyError:
-        pass
+
+    # delete some coords
+    for coord_name in ['acq_time']:
+        try:
+            del scene['lat'].coords[coord_name]
+            del scene['lon'].coords[coord_name]
+        except KeyError:
+            pass
 
 
 def set_header_and_band_attrs_defaults(scene, BANDNAMES, PPS_TAGNAMES, REFL_BANDS, irch):
@@ -289,7 +298,7 @@ def set_header_and_band_attrs_defaults(scene, BANDNAMES, PPS_TAGNAMES, REFL_BAND
 def update_angle_attributes(scene, band):
     """Set and delete angle attributes."""
     for angle in PPS_ANGLE_TAGS:
-        if angle not in scene.keys() and angle in ['sunazimuth', 'satazimuth']:
+        if angle not in scene and angle in ['sunazimuth', 'satazimuth']:
             # azimuth angles not always there
             continue
         scene[angle].attrs['id_tag'] = angle
@@ -309,10 +318,11 @@ def update_angle_attributes(scene, band):
             except KeyError:
                 pass
         # delete some coords
-        try:
-            del scene[angle].coords['acq_time']
-        except KeyError:
-            pass
+        for coord_name in ['acq_time']:
+            try:
+                del scene[angle].coords[coord_name]
+            except KeyError:
+                pass
 
 
 def apply_sunz_correction(scene, REFL_BANDS):

--- a/level1c4pps/gac2pps_lib.py
+++ b/level1c4pps/gac2pps_lib.py
@@ -166,6 +166,8 @@ def process_one_file(gac_file, out_path='.', reader_kwargs=None):
                        header_attrs=get_header_attrs(scn_, band=irch, sensor='avhrr'),
                        engine='netcdf4',
                        flatten_attrs=True,
+                       include_lonlats=False,  # Included anyway as they are datasets in scn_
+                       pretty=True,
                        encoding=get_encoding_gac(scn_))
 
     print("Saved file {:s} after {:3.1f} seconds".format(


### PR DESCRIPTION
Get rid of acq_time, latitude, longitude and satazimuth_acq_time variable showing up in level1c file by being added in cf_writer.

Use pretty_formatting to avoid satazimuth_acq_time showing up.
Fixed bad use of scene.keys() so that acq_time is removed also from satzenith and sunzenith.
Also set include_lonlats=False to avoid that longitude and latitude are included again.
That did not help for current satpy master though.
A PR is on the way to satpy to fix it.