### PR TITLE
Handle y, x dimension names also for metimage

### DIFF
--- a/level1c4pps/metimage2pps_lib.py
+++ b/level1c4pps/metimage2pps_lib.py
@@ -93,10 +93,12 @@ def process_one_scene(scene_files, out_path):
 
     # Transpose data to get scanlines as row dimension
     for key in BANDNAMES + ANGLE_NAMES + ['lat_pixels', 'lon_pixels']:
-        try:
+        if 'lat_pixels' in scn_[key].dims:
+            # satpy <= 0 .26.0
             scn_[key] = scn_[key].transpose('num_lines', 'num_pixels')
-        except KeyError:
-            pass
+        elif scn_[key].dims[0] == 'x':
+            # first dim should be y
+            scn_[key] = scn_[key].transpose('y', 'x')
 
     # one ir channel
     irch = scn_['vii_10690']


### PR DESCRIPTION
The dimensions for vii are planned to be standardized to the normal
satpy y, x. Both name and order will be changed compared to version 0.26.0.

https://github.com/pytroll/satpy/pull/1613