### PR TITLE
Change wavelenght format to match pps-level1c

### DIFF
--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -260,6 +260,7 @@ def set_attrs(scene):
         idtag = PPS_TAGNAMES[band]
         scene[band].attrs['id_tag'] = idtag
         scene[band].attrs['description'] = 'SEVIRI ' + str(band)
+        scene[band].attrs['wavelength'] = scene[band].attrs['wavelength'][0:3]
         if 'sun_earth_distance_correction_factor' not in scene[band].attrs:
             scene[band].attrs['sun_earth_distance_correction_applied'] = False
             scene[band].attrs['sun_earth_distance_correction_factor'] = 1.0

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -260,7 +260,9 @@ def set_attrs(scene):
         idtag = PPS_TAGNAMES[band]
         scene[band].attrs['id_tag'] = idtag
         scene[band].attrs['description'] = 'SEVIRI ' + str(band)
-        scene[band].attrs['wavelength'] = scene[band].attrs['wavelength'][0:3]
+        scene[band].attrs['wavelength'] = [scene[band].attrs['wavelength'].min,
+                                           scene[band].attrs['wavelength'].central,
+                                           scene[band].attrs['wavelength'].max]
         if 'sun_earth_distance_correction_factor' not in scene[band].attrs:
             scene[band].attrs['sun_earth_distance_correction_applied'] = False
             scene[band].attrs['sun_earth_distance_correction_factor'] = 1.0

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -36,6 +36,7 @@ import level1c4pps.seviri2pps_lib as seviri2pps
 import level1c4pps.calibration_coefs as calib
 from satpy.dataset.dataid import WavelengthRange
 
+
 def get_fake_scene():
     scene = Scene()
     start_time = dt.datetime(2020, 1, 1, 12)
@@ -198,7 +199,7 @@ class TestSeviri2PPS(unittest.TestCase):
     def test_set_attrs(self):
         """Test setting scene attributes."""
         seviri2pps.BANDNAMES = ['VIS006', 'IR_108']
-        vis006 = mock.MagicMock(attrs={ 'wavelength': WavelengthRange(0.56, 0.635, 0.71)})
+        vis006 = mock.MagicMock(attrs={'wavelength': WavelengthRange(0.56, 0.635, 0.71)})
         ir108 = mock.MagicMock(attrs={'platform_name': 'myplatform',
                                       'wavelength': WavelengthRange(9.8, 10.8, 11.8),
                                       'orbital_parameters': {'orb_a': 1,
@@ -248,7 +249,7 @@ class TestSeviri2PPS(unittest.TestCase):
                               dims=('x',),
                               coords={'acq_time': ('x', [0, 0, 0])},
                               attrs={'area': 'myarea',
-                                      'wavelength': WavelengthRange(0.56, 0.635, 0.71),
+                                     'wavelength': WavelengthRange(0.56, 0.635, 0.71),
                                      'start_time': dt.datetime(2009, 7, 1, 0)})
         ir_108 = xr.DataArray(data=[4, 5, 6],
                               dims=('x',),
@@ -487,6 +488,7 @@ class TestSeviri2PPS(unittest.TestCase):
         # Original array should not be modified
         self.assertEqual(arr.attrs['start_time'], start_time)
         self.assertEqual(arr.attrs['end_time'], end_time)
+
 
 class TestCalibration(unittest.TestCase):
     """Test SEVIRI calibration."""

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -45,14 +45,16 @@ def get_fake_scene():
         dims=('y', 'x'),
         attrs={'calibration': 'reflectance',
                'sun_earth_distance_correction_applied': True,
-               'start_time': start_time}
+               'start_time': start_time,
+               'wavelength': [0.56, 0.635, 0.71, 'um']}
     )
     scene['IR_108'] = xr.DataArray(
         [[5, 6],
          [7, 8]],
         dims=('y', 'x'),
         attrs={'calibration': 'brightness_temperature',
-               'start_time': start_time}
+               'start_time': start_time,
+               'wavelength': [9.8, 10.8, 11.8, 'um']}
     )
     scene.attrs['sensor'] = {'seviri'}
     return scene
@@ -196,8 +198,9 @@ class TestSeviri2PPS(unittest.TestCase):
     def test_set_attrs(self):
         """Test setting scene attributes."""
         seviri2pps.BANDNAMES = ['VIS006', 'IR_108']
-        vis006 = mock.MagicMock(attrs={})
+        vis006 = mock.MagicMock(attrs={'wavelength': [0.56, 0.635, 0.71, 'um']})
         ir108 = mock.MagicMock(attrs={'platform_name': 'myplatform',
+                                      'wavelength': [9.8, 10.8, 11.8, 'um'],
                                       'orbital_parameters': {'orb_a': 1,
                                                              'orb_b': 2},
                                       'georef_offset_corrected': True})
@@ -245,11 +248,13 @@ class TestSeviri2PPS(unittest.TestCase):
                               dims=('x',),
                               coords={'acq_time': ('x', [0, 0, 0])},
                               attrs={'area': 'myarea',
+                                     'wavelength': [0.56, 0.635, 0.71, 'um'],
                                      'start_time': dt.datetime(2009, 7, 1, 0)})
         ir_108 = xr.DataArray(data=[4, 5, 6],
                               dims=('x',),
                               coords={'acq_time': ('x', [0, 0, 0])},
-                              attrs={'start_time': dt.datetime(2009, 7, 1, 1)})
+                              attrs={'start_time': dt.datetime(2009, 7, 1, 1),
+                                     'wavelength': [9.8, 10.8, 11.8, 'um']})
         scene_dict = {'VIS006': vis006.copy(), 'IR_108': ir_108.copy()}
         scene = mock.MagicMock(attrs={})
         scene.__getitem__.side_effect = scene_dict.__getitem__

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -34,7 +34,7 @@ from satpy import Scene
 
 import level1c4pps.seviri2pps_lib as seviri2pps
 import level1c4pps.calibration_coefs as calib
-
+from satpy.dataset.dataid import WavelengthRange
 
 def get_fake_scene():
     scene = Scene()
@@ -46,7 +46,7 @@ def get_fake_scene():
         attrs={'calibration': 'reflectance',
                'sun_earth_distance_correction_applied': True,
                'start_time': start_time,
-               'wavelength': [0.56, 0.635, 0.71, 'um']}
+               'wavelength': WavelengthRange(0.56, 0.635, 0.71)}
     )
     scene['IR_108'] = xr.DataArray(
         [[5, 6],
@@ -54,7 +54,7 @@ def get_fake_scene():
         dims=('y', 'x'),
         attrs={'calibration': 'brightness_temperature',
                'start_time': start_time,
-               'wavelength': [9.8, 10.8, 11.8, 'um']}
+               'wavelength': WavelengthRange(9.8, 10.8, 11.8)}
     )
     scene.attrs['sensor'] = {'seviri'}
     return scene
@@ -198,9 +198,9 @@ class TestSeviri2PPS(unittest.TestCase):
     def test_set_attrs(self):
         """Test setting scene attributes."""
         seviri2pps.BANDNAMES = ['VIS006', 'IR_108']
-        vis006 = mock.MagicMock(attrs={'wavelength': [0.56, 0.635, 0.71, 'um']})
+        vis006 = mock.MagicMock(attrs={ 'wavelength': WavelengthRange(0.56, 0.635, 0.71)})
         ir108 = mock.MagicMock(attrs={'platform_name': 'myplatform',
-                                      'wavelength': [9.8, 10.8, 11.8, 'um'],
+                                      'wavelength': WavelengthRange(9.8, 10.8, 11.8),
                                       'orbital_parameters': {'orb_a': 1,
                                                              'orb_b': 2},
                                       'georef_offset_corrected': True})
@@ -248,13 +248,13 @@ class TestSeviri2PPS(unittest.TestCase):
                               dims=('x',),
                               coords={'acq_time': ('x', [0, 0, 0])},
                               attrs={'area': 'myarea',
-                                     'wavelength': [0.56, 0.635, 0.71, 'um'],
+                                      'wavelength': WavelengthRange(0.56, 0.635, 0.71),
                                      'start_time': dt.datetime(2009, 7, 1, 0)})
         ir_108 = xr.DataArray(data=[4, 5, 6],
                               dims=('x',),
                               coords={'acq_time': ('x', [0, 0, 0])},
                               attrs={'start_time': dt.datetime(2009, 7, 1, 1),
-                                     'wavelength': [9.8, 10.8, 11.8, 'um']})
+                                     'wavelength': WavelengthRange(9.8, 10.8, 11.8)})
         scene_dict = {'VIS006': vis006.copy(), 'IR_108': ir_108.copy()}
         scene = mock.MagicMock(attrs={})
         scene.__getitem__.side_effect = scene_dict.__getitem__


### PR DESCRIPTION
PPS (2021) need the wavelength attribute to be a list with min, center, max
value for the wavelength.

<!-- Describe what your PR does, and why -->

 - [x] Closes #63 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->

