### PR TITLE
Add clipping for SEVIRI calibration coefficients

### DIFF
--- a/level1c4pps/calibration_coefs.py
+++ b/level1c4pps/calibration_coefs.py
@@ -24,33 +24,95 @@
 """Module with calibration coefficients for SEVIRI."""
 
 import datetime
+from enum import Enum
 
-CALIB_MODE = 'Nominal'
-COEFS_MEIRINK = dict(
-    MSG1=dict(
-        VIS006=dict(b=24.346, a=0.3739E-3),
-        VIS008=dict(b=30.989, a=0.3111E-3),
-        IR_016=dict(b=22.869, a=0.0065E-3)
-    ),
-    MSG2=dict(
-        VIS006=dict(b=21.026, a=0.2556E-3),
-        VIS008=dict(b=26.875, a=0.1835E-3),
-        IR_016=dict(b=21.394, a=0.0498E-3)
-    ),
-    MSG3=dict(
-        VIS006=dict(b=19.829, a=0.5856E-3),
-        VIS008=dict(b=25.284, a=0.6787E-3),
-        IR_016=dict(b=23.066, a=-0.0286E-3)
-    ),
-    MSG4=dict(
-        VIS006=dict(b=21.040, a=0.2877E-3),
-        VIS008=dict(b=24.966, a=0.6074E-3),
-        IR_016=dict(b=21.236, a=0.1420E-3)
+
+class CalibrationData(Enum):
+    COEFS = dict(
+        MSG1=dict(
+            VIS006=dict(b=24.346, a=0.3739E-3),
+            VIS008=dict(b=30.989, a=0.3111E-3),
+            IR_016=dict(b=22.869, a=0.0065E-3)
+        ),
+        MSG2=dict(
+            VIS006=dict(b=21.026, a=0.2556E-3),
+            VIS008=dict(b=26.875, a=0.1835E-3),
+            IR_016=dict(b=21.394, a=0.0498E-3)
+        ),
+        MSG3=dict(
+            VIS006=dict(b=19.829, a=0.5856E-3),
+            VIS008=dict(b=25.284, a=0.6787E-3),
+            IR_016=dict(b=23.066, a=-0.0286E-3)
+        ),
+        MSG4=dict(
+            VIS006=dict(b=21.040, a=0.2877E-3),
+            VIS008=dict(b=24.966, a=0.6074E-3),
+            IR_016=dict(b=21.236, a=0.1420E-3)
+        )
     )
-)
+    SPACE_COUNT = -51.0
+    REF_TIME = datetime.datetime(2000, 1, 1, 0, 0)
+    TIME_COVERAGE = {
+        "start": datetime.datetime(2004, 1, 1, 0, 0),
+        "end": datetime.datetime(2021, 1, 1, 0, 0)
+    }
+    SATPY_CALIB_MODE = 'Nominal'
 
-REF_TIME = datetime.datetime(2000, 1, 1, 0, 0)
-SPACE_COUNT = -51.0
+
+def get_calibration(platform, time, clip_time=True):
+    """Get MODIS-intercalibrated gain and offset for specific time.
+
+    Args:
+        platform: Platform name.
+        time: Date or time of observations to be calibrated.
+        clip_time: If True, do not extrapolate calibration
+            coefficients beyond the time coverage of the calibration dataset.
+            Instead, clip at the boundaries, that means return the boundary
+            coefficients for timestamps outside the coverage.
+    """
+    coefs = {}
+    for channel in ('VIS006', 'VIS008', 'IR_016'):
+        coefs[channel] = _get_single_channel_calibration(
+            platform=platform,
+            channel=channel,
+            time=time,
+            clip_time=clip_time
+        )
+    return coefs
+
+
+def _get_single_channel_calibration(platform, channel, time, clip_time):
+    time = _prepare_time(time, clip_time)
+    gain, offset = calib_meirink(platform, channel, time)
+    return {'gain': gain, 'offset': offset}
+
+
+def _prepare_time(time, clip_time):
+    time = _convert_to_datetime(time)
+    _check_time(time)
+    if clip_time:
+        time = _clip_time_at_coverage_bounds(time)
+    return time
+
+
+def _convert_to_datetime(date_or_time):
+    if isinstance(date_or_time, datetime.date):
+        return datetime.datetime.combine(date_or_time, datetime.time(0))
+    return date_or_time
+
+
+def _check_time(time):
+    ref_time = CalibrationData.REF_TIME.value
+    if time < ref_time:
+        raise ValueError('Given time ({0}) is < reference time ({1})'.format(
+            time, ref_time))
+
+
+def _clip_time_at_coverage_bounds(time):
+    time_cov = CalibrationData.TIME_COVERAGE.value
+    time = max(time, time_cov["start"])
+    time = min(time, time_cov["end"])
+    return time
 
 
 def calib_meirink(platform, channel, time):
@@ -60,50 +122,27 @@ def calib_meirink(platform, channel, time):
 
     :returns: gain, offset [mW m-2 sr-1 (cm-1)-1]
     """
-    time = _convert_to_datetime(time)
-    _check_time(time)
-    a = COEFS_MEIRINK[platform][channel]['a']
-    b = COEFS_MEIRINK[platform][channel]['b']
+    coefs = CalibrationData.COEFS.value
+    a = coefs[platform][channel]['a']
+    b = coefs[platform][channel]['b']
     days_since_ref_time = _get_days_since_ref_time(time)
     return _calc_gain_offset(a, b, days_since_ref_time)
 
 
-def _check_time(time):
-    if time < REF_TIME:
-        raise ValueError('Given time ({0}) is < reference time ({1})'.format(
-            time, REF_TIME))
-
-
-def _convert_to_datetime(date_or_time):
-    if isinstance(date_or_time, datetime.date):
-        return datetime.datetime.combine(date_or_time, datetime.time(0))
-    return date_or_time
-
-
 def _get_days_since_ref_time(time):
-    return (time - REF_TIME).total_seconds() / 3600.0 / 24.0
+    ref_time = CalibrationData.REF_TIME.value
+    return (time - ref_time).total_seconds() / 3600.0 / 24.0
 
 
 def _calc_gain_offset(a, b, days_since_ref_time):
     gain = (b + a * days_since_ref_time)
     gain = _microwatts_to_milliwatts(gain)
-    offset = SPACE_COUNT * gain
+    offset = CalibrationData.SPACE_COUNT.value * gain
     return gain, offset
 
 
 def _microwatts_to_milliwatts(microwatts):
     return microwatts / 1000.0
-
-
-def get_calibration(platform, time):
-    """Get MODIS-intercalibrated gain and offset for specific time."""
-    coefs = {}
-    for channel in ('VIS006', 'VIS008', 'IR_016'):
-        gain, offset = calib_meirink(platform=platform, channel=channel,
-                                     time=time)
-        coefs[channel] = {'gain': gain, 'offset': offset}
-
-    return coefs
 
 
 if __name__ == '__main__':

--- a/level1c4pps/calibration_coefs.py
+++ b/level1c4pps/calibration_coefs.py
@@ -56,7 +56,7 @@ SPACE_COUNT = -51.0
 def calib_meirink(platform, channel, time):
     """Get MODIS-intercalibrated gain and offset for SEVIRI VIS channels.
 
-    Reference: http://msgcpp.knmi.nl/mediawiki/index.php/MSG-SEVIRI_solar_channel_calibration
+    Reference: https://msgcpp.knmi.nl/solar-channel-calibration.html
 
     :returns: gain, offset [mW m-2 sr-1 (cm-1)-1]
     """

--- a/level1c4pps/calibration_coefs.py
+++ b/level1c4pps/calibration_coefs.py
@@ -59,7 +59,7 @@ class CalibrationData(Enum):
     SATPY_CALIB_MODE = 'Nominal'
 
 
-def get_calibration(platform, time, clip=True):
+def get_calibration(platform, time, clip=False):
     """Get MODIS-intercalibrated gain and offset for specific time.
 
     Args:

--- a/level1c4pps/calibration_coefs.py
+++ b/level1c4pps/calibration_coefs.py
@@ -59,16 +59,16 @@ class CalibrationData(Enum):
     SATPY_CALIB_MODE = 'Nominal'
 
 
-def get_calibration(platform, time, clip_time=True):
+def get_calibration(platform, time, clip=True):
     """Get MODIS-intercalibrated gain and offset for specific time.
 
     Args:
         platform: Platform name.
         time: Date or time of observations to be calibrated.
-        clip_time: If True, do not extrapolate calibration
-            coefficients beyond the time coverage of the calibration dataset.
-            Instead, clip at the boundaries, that means return the boundary
-            coefficients for timestamps outside the coverage.
+        clip: If True, do not extrapolate calibration coefficients beyond the
+            time coverage of the calibration dataset. Instead, clip at the
+            boundaries, that means return the boundary coefficients for
+            timestamps outside the coverage.
     """
     coefs = {}
     for channel in ('VIS006', 'VIS008', 'IR_016'):
@@ -76,22 +76,22 @@ def get_calibration(platform, time, clip_time=True):
             platform=platform,
             channel=channel,
             time=time,
-            clip_time=clip_time
+            clip=clip
         )
     return coefs
 
 
-def _get_single_channel_calibration(platform, channel, time, clip_time):
-    time = _prepare_time(time, clip_time)
+def _get_single_channel_calibration(platform, channel, time, clip):
+    time = _prepare_time(time, clip)
     gain, offset = calib_meirink(platform, channel, time)
     return {'gain': gain, 'offset': offset}
 
 
-def _prepare_time(time, clip_time):
+def _prepare_time(time, clip):
     time = _convert_to_datetime(time)
     _check_time(time)
-    if clip_time:
-        time = _clip_time_at_coverage_bounds(time)
+    if clip:
+        time = _clip_at_coverage_bounds(time)
     return time
 
 
@@ -108,7 +108,7 @@ def _check_time(time):
             time, ref_time))
 
 
-def _clip_time_at_coverage_bounds(time):
+def _clip_at_coverage_bounds(time):
     time_cov = CalibrationData.TIME_COVERAGE.value
     time = max(time, time_cov["start"])
     time = min(time, time_cov["end"])

--- a/level1c4pps/calibration_coefs.py
+++ b/level1c4pps/calibration_coefs.py
@@ -82,6 +82,14 @@ def get_calibration(platform, time, clip=False):
 
 
 def _get_single_channel_calibration(platform, channel, time, clip):
+    """Get calibration coefficients for a single channel.
+
+    Args:
+        platform: Platform name.
+        channel: Channel name.
+        time: Observation date or time.
+        clip: Clip at time coverage boundaries of the calibration dataset.
+    """
     time = _prepare_time(time, clip)
     gain, offset = calib_meirink(platform, channel, time)
     return {'gain': gain, 'offset': offset}

--- a/level1c4pps/calibration_coefs.py
+++ b/level1c4pps/calibration_coefs.py
@@ -89,19 +89,24 @@ def _get_single_channel_calibration(platform, channel, time, clip):
 
 def _prepare_time(time, clip):
     time = _convert_to_datetime(time)
-    _check_time(time)
+    _check_is_valid_time(time)
     if clip:
         time = _clip_at_coverage_bounds(time)
     return time
 
 
 def _convert_to_datetime(date_or_time):
-    if isinstance(date_or_time, datetime.date):
+    if _is_date(date_or_time):
         return datetime.datetime.combine(date_or_time, datetime.time(0))
     return date_or_time
 
 
-def _check_time(time):
+def _is_date(date_or_time):
+    # datetime is a subclass of date, therefore we cannot use isinstance here
+    return type(date_or_time) == datetime.date
+
+
+def _check_is_valid_time(time):
     ref_time = CalibrationData.REF_TIME.value
     if time < ref_time:
         raise ValueError('Given time ({0}) is < reference time ({1})'.format(

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -89,7 +89,8 @@ NATIVE_FILE_PATTERN = ('{platform_shortname:4s}-{instr:4s}-'
 # MSG4-SEVI-MSG15-1234-NA-20190409121243.927000000Z
 
 
-def load_and_calibrate(filenames, apply_sun_earth_distance_correction, rotate):
+def load_and_calibrate(filenames, apply_sun_earth_distance_correction, rotate,
+                       clip_calib):
     """Load and calibrate data.
 
     Uses inter-calibration coefficients from Meirink et al.
@@ -99,6 +100,9 @@ def load_and_calibrate(filenames, apply_sun_earth_distance_correction, rotate):
         apply_sun_earth_distance_correction: If True, apply sun-earth-distance-
             correction to visible channels.
         rotate: Rotate image so that pixel (0, 0) is N-W.
+        clip_calib: If True, do not extrapolate calibration coefficients beyond
+            the time coverage of the calibration dataset. Instead, clip at the
+            boundaries.
 
     Returns:
         Satpy scene holding calibrated channels
@@ -109,7 +113,8 @@ def load_and_calibrate(filenames, apply_sun_earth_distance_correction, rotate):
 
     calib_coefs = get_calibration(
         platform=info['platform_shortname'],
-        time=info['start_time']
+        time=info['start_time'],
+        clip=clip_calib
     )
     scn_ = _create_scene(file_format, filenames, calib_coefs)
     _check_is_seviri_data(scn_)
@@ -558,7 +563,8 @@ class SEVIRIFilenameParser:
 
 def process_one_scan(tslot_files, out_path, rotate=True, engine='h5netcdf',
                      use_nominal_time_in_filename=False,
-                     apply_sun_earth_distance_correction=True):
+                     apply_sun_earth_distance_correction=True,
+                     clip_calib=False):
     """Make level 1c files in PPS-format."""
     for fname in tslot_files:
         if not os.path.isfile(fname):
@@ -568,7 +574,8 @@ def process_one_scan(tslot_files, out_path, rotate=True, engine='h5netcdf',
     scn_ = load_and_calibrate(
         tslot_files,
         apply_sun_earth_distance_correction=apply_sun_earth_distance_correction,
-        rotate=rotate
+        rotate=rotate,
+        clip_calib=clip_calib
     )
 
     # Find lat/lon data

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -43,7 +43,7 @@ from trollsift.parser import globify, Parser
 from pyorbital.astronomy import get_alt_az, sun_zenith_angle
 from pyorbital.orbital import get_observer_look
 
-from level1c4pps.calibration_coefs import get_calibration_for_time, CALIB_MODE
+from level1c4pps.calibration_coefs import get_calibration, CALIB_MODE
 from level1c4pps import make_azidiff_angle, get_encoding, compose_filename, update_angle_attributes
 
 
@@ -107,7 +107,7 @@ def load_and_calibrate(filenames, apply_sun_earth_distance_correction, rotate):
     parser = SEVIRIFilenameParser()
     file_format, info = parser.parse(os.path.basename(filenames[0]))
 
-    calib_coefs = get_calibration_for_time(
+    calib_coefs = get_calibration(
         platform=info['platform_shortname'],
         time=info['start_time']
     )

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -43,7 +43,7 @@ from trollsift.parser import globify, Parser
 from pyorbital.astronomy import get_alt_az, sun_zenith_angle
 from pyorbital.orbital import get_observer_look
 
-from level1c4pps.calibration_coefs import get_calibration, CALIB_MODE
+from level1c4pps.calibration_coefs import get_calibration, CalibrationData
 from level1c4pps import make_azidiff_angle, get_encoding, compose_filename, update_angle_attributes
 
 
@@ -123,10 +123,12 @@ def load_and_calibrate(filenames, apply_sun_earth_distance_correction, rotate):
 
 
 def _create_scene(file_format, filenames, calib_coefs):
-    return Scene(reader=file_format,
-                 filenames=filenames,
-                 reader_kwargs={'calib_mode': CALIB_MODE,
-                                'ext_calib_coefs': calib_coefs})
+    return Scene(
+        reader=file_format,
+        filenames=filenames,
+        reader_kwargs={'calib_mode': CalibrationData.SATPY_CALIB_MODE.value,
+                       'ext_calib_coefs': calib_coefs}
+    )
 
 
 def _check_is_seviri_data(scene):

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -571,6 +571,18 @@ class TestCalibration:
                         'IR_016': {'gain': 0.022223894,
                                    'offset': -1.1334185940000001}
                     }
+                ),
+                (
+                    'MSG4',
+                    dt.datetime(2024, 1, 18, 0, 0),
+                    {
+                        'VIS006': {'gain': 0.0235668691,
+                                   'offset': -1.2019103241},
+                        'VIS008': {'gain': 0.0303007942,
+                                   'offset': -1.5453405042000001},
+                        'IR_016': {'gain': 0.022483186,
+                                   'offset': -1.146642486}
+                    }  # extrapolation beyond time coverage of calib. dataset
                 )
             ]
         )
@@ -596,13 +608,15 @@ class TestCalibration:
         ]
     )
     def test_clip_at_time_coverage_bounds(self, coverage_boundary, outside_coverage):
+        """Test clipping beyond time coverage of the calibration dataset."""
         coefs1 = calib.get_calibration(
             platform='MSG1',
             time=coverage_boundary
         )
         coefs2 = calib.get_calibration(
             platform='MSG1',
-            time=outside_coverage
+            time=outside_coverage,
+            clip=True
         )
         self._assert_coefs_close(coefs1, coefs2)
 

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -606,6 +606,13 @@ class TestCalibration:
         )
         self._assert_coefs_close(coefs1, coefs2)
 
+    def test_fails_with_invalid_time(self):
+        with pytest.raises(ValueError):
+            calib.get_calibration(
+                platform='MSG1',
+                time=dt.datetime(1999, 1, 1)
+            )
+
 
 class TestSEVIRIFilenameParser(unittest.TestCase):
     def test_parse_native(self):

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -500,7 +500,7 @@ class TestCalibration:
         "time",
         (dt.date(2018, 1, 18), dt.datetime(2018, 1, 18))
     )
-    def test_get_calibration_for_date(self, time):
+    def test_get_calibration_can_handle_both_date_and_time(self, time):
         """Test MODIS-intercalibrated gain and offset for specific date."""
         coefs = calib.get_calibration(
             platform='MSG3', time=time)
@@ -575,7 +575,7 @@ class TestCalibration:
             ]
         )
     )
-    def test_get_calibration_for_time(self, platform, timestamp, expected):
+    def test_get_calibration(self, platform, timestamp, expected):
         """Test MODIS-intercalibrated gain and offset for specific time."""
         coefs = calib.get_calibration(platform=platform, time=timestamp)
         self._assert_coefs_close(coefs, expected)

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -586,6 +586,24 @@ class TestCalibration:
             platform='MSG3', time=dt.datetime(2018, 1, 19))
         self._assert_coefs_close(coefs1, coefs2, atol=1e-4)
 
+    @pytest.mark.parametrize(
+        "coverage_boundary,outside_coverage",
+        [
+            (dt.datetime(2004, 1, 1), dt.datetime(2003, 1, 1)),
+            (dt.datetime(2021, 1, 1), dt.datetime(2022, 1, 1)),
+        ]
+    )
+    def test_clip_at_time_coverage_bounds(self, coverage_boundary, outside_coverage):
+        coefs1 = calib.get_calibration(
+            platform='MSG1',
+            time=coverage_boundary
+        )
+        coefs2 = calib.get_calibration(
+            platform='MSG1',
+            time=outside_coverage
+        )
+        self._assert_coefs_close(coefs1, coefs2)
+
 
 class TestSEVIRIFilenameParser(unittest.TestCase):
     def test_parse_native(self):

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -621,6 +621,7 @@ class TestCalibration:
         self._assert_coefs_close(coefs1, coefs2)
 
     def test_fails_with_invalid_time(self):
+        """Test that calibration fails with timestamps < reference time."""
         with pytest.raises(ValueError):
             calib.get_calibration(
                 platform='MSG1',

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -76,7 +76,8 @@ class TestSeviri2PPS(unittest.TestCase):
         res = seviri2pps.load_and_calibrate(
             filenames,
             apply_sun_earth_distance_correction=False,
-            rotate=False
+            rotate=False,
+            clip_calib=False
         )
 
         # Compare results and expectations
@@ -105,7 +106,8 @@ class TestSeviri2PPS(unittest.TestCase):
         res = seviri2pps.load_and_calibrate(
             filenames,
             apply_sun_earth_distance_correction=False,
-            rotate=True
+            rotate=True,
+            clip_calib=False
         )
         scene.load.assert_called_with(mock.ANY, upper_right_corner='NE')
         self.assertTrue(res.attrs['image_rotated'])


### PR DESCRIPTION
SEVIRI calibration coefficients are obtained from an inter-calibration with MODIS over a specific time coverage. They are valid for that time coverage, but not necessarily beyond. Instead of extrapolating coefficients beyond the coverage, a conservative approach is to clip calibration coefficients at the coverage boundaries. This PR adds an option `clip_calib` to do this. By default clipping is disabled.

The time coverage of the current inter-calibration dataset is 2004-2020 (inclusive), see https://msgcpp.knmi.nl/solar-channel-calibration.html. That means with this PR
-  `get_calibration(time=2024-01-01)` will return the coefficients from 2021-01-01 and
-  `get_calibration(time=2000-01-01)` will return coefficients from 2004-01-01

Along the way I 
- merged the two methods `calib_meirink` and `calib_meirink_date` because they were basically identical
- refactored calibration methods to improve readability
- simplified the corresponding tests using pytest

Background: This is required for the CLAAS-3 ICDR.

 - [X] Tests added
 - [x] Tests passed: Passes ``pytest level1c4pps``
 - [X] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
