### PR TITLE
Pyspectral 1.7.2 and satpy <= 0.37 for gac data

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         experimental: [false]
         include:
           - python-version: "3.9"

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -23,7 +23,7 @@ dependencies:
   - mock
   - numpy
   - xarray
-  - satpy
+  - satpy=0.37
   - pyspectral
   - h5netcdf
   - pyorbital

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -97,6 +97,7 @@ class TestSeviri2PPS(unittest.TestCase):
             dims=('y', 'x')
         )
         if res['VIS006'][0, 0] > 1.04:
+            # pyspectral 1.7.1 and older
             xr.testing.assert_allclose(res['VIS006'], vis006_exp_pyspectral_1_7_1)
         else:
             xr.testing.assert_allclose(res['VIS006'], vis006_exp)

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -81,9 +81,14 @@ class TestSeviri2PPS(unittest.TestCase):
         )
 
         # Compare results and expectations
-        vis006_exp = xr.DataArray(
+        vis006_exp_pyspectral_1_7_1 = xr.DataArray(
             [[1.07025268, 2.14050537],
              [3.21075805, 4.28101074]],
+            dims=('y', 'x')
+        )
+        vis006_exp = xr.DataArray(
+            [[1.034205, 2.06841],
+             [3.102615, 4.13682]],
             dims=('y', 'x')
         )
         ir_108_exp = xr.DataArray(
@@ -91,7 +96,10 @@ class TestSeviri2PPS(unittest.TestCase):
              [7, 8]],
             dims=('y', 'x')
         )
-        xr.testing.assert_allclose(res['VIS006'], vis006_exp)
+        if res['VIS006'][0, 0] > 1.04:
+            xr.testing.assert_allclose(res['VIS006'], vis006_exp_pyspectral_1_7_1)
+        else:
+            xr.testing.assert_allclose(res['VIS006'], vis006_exp)
         xr.testing.assert_equal(res['IR_108'], ir_108_exp)
         self.assertFalse(
             res['VIS006'].attrs['sun_earth_distance_correction_applied'],

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     pass
 
-requires = ['satpy >= 0.19', 'pyorbital', 'trollsift', 'pyspectral', 'h5netcdf'],
+requires = ['satpy <= 0.37', 'pyorbital', 'trollsift', 'pyspectral', 'h5netcdf'],
 
 NAME = "level1c4pps"
 README = open('README.md', 'r').read()


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Use only satpy <= 0.37 
