### PR TITLE
Remove etuptools_scm_git_archive

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
 ref-names: $Format:%D$

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [options]
 setup_requires =
     setuptools_scm
-    setuptools_scm_git_archive
 
 [bdist_rpm]
 provides=level1c4pps


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Remove setuptools_scm_git_archive it is depricated.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
