### PR TITLE
Adjust Satpy version limit

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -23,7 +23,7 @@ dependencies:
   - mock
   - numpy
   - xarray
-  - satpy<=0.37,>0.41.1
+  - satpy<0.38|>0.41.1
   - pyspectral
   - h5netcdf
   - pyorbital

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -23,7 +23,7 @@ dependencies:
   - mock
   - numpy
   - xarray
-  - satpy=0.37
+  - satpy<=0.37,>0.41.1
   - pyspectral
   - h5netcdf
   - pyorbital

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     pass
 
-requires = ['satpy <= 0.37, > 0.41.1', 'pyorbital', 'trollsift', 'pyspectral', 'h5netcdf'],
+requires = ['satpy!=0.38.*,!=0.39.*,!=0.40.*,!=0.41.*', 'pyorbital', 'trollsift', 'pyspectral', 'h5netcdf'],
 
 NAME = "level1c4pps"
 README = open('README.md', 'r').read()

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ try:
 except ImportError:
     pass
 
-requires = ['satpy <= 0.37', 'pyorbital', 'trollsift', 'pyspectral', 'h5netcdf'],
+requires = ['satpy <= 0.37, > 0.41.1', 'pyorbital', 'trollsift', 'pyspectral', 'h5netcdf'],
 
 NAME = "level1c4pps"
 README = open('README.md', 'r').read()


### PR DESCRIPTION
This PR adjusts the Satpy version limit so that when https://github.com/pytroll/satpy/pull/2451 has been released the new versions of Satpy can be used.

 - [x] Closes #74 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
