### PR TITLE
removed check for pygac and numpy2.0 gac2pps_lib.py

### DIFF
--- a/level1c4pps/gac2pps_lib.py
+++ b/level1c4pps/gac2pps_lib.py
@@ -42,12 +42,6 @@ import logging
 from packaging.version import Version
 logger = logging.getLogger('gac2pps')
 
-if Version(np.__version__) >= Version('2.0.0'):
-    if Version(pygac.__version__) == Version('1.7.3'):
-        raise ImportError("pygac 1.7.3 requires numpy < 2.0.0")
-    else:
-        logger.warning("pygac 1.7.3 requires numpy < 2.0.0 or greater")
-
 
 
 BANDNAMES = ['1', '2', '3', '3a', '3b', '4', '5']


### PR DESCRIPTION
removed the check for numpy2.0 as pygac now supports numpy2
