### PR TITLE
vgac time units

### DIFF
--- a/bin/vgac2pps.py
+++ b/bin/vgac2pps.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     parser.add_argument('-all_ch', '--all_channels', action='store_true',
                         help="Save all 21 channels to level1c4pps file.")
     parser.add_argument('-n19', '--as_noaa19',
-                        options=[version for version in SBAF],
+                        choices=[version for version in SBAF],
                         default=None,
                         help=("Save only the AVHRR (1,2, 3B, 4, 5) channels to level1c4pps file. "
                               "And apply SBAFs to the channels."))

--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -320,9 +320,11 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
                'complevel': 4, '_FillValue': -32001.0}
     elif name in ['scanline_timestamps']:
         # pygac scanline_timestamps
-        enc = {'dtype': 'int64', 'zlib': True,
-               'units': 'Milliseconds since 1970-01-01',
-               'complevel': 4, '_FillValue': -1.0}
+        enc = {'dtype': 'float64',
+               'zlib': True,
+               'units': 'milliseconds since 1970-01-01',
+               'complevel': 4,
+               '_FillValue': -1.0}
     if not enc:
         raise ValueError('Unsupported band: {}'.format(name))
     return name, enc

--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -320,7 +320,7 @@ def get_band_encoding(dataset, bandnames, pps_tagnames, chunks=None):
                'complevel': 4, '_FillValue': -32001.0}
     elif name in ['scanline_timestamps']:
         # pygac scanline_timestamps
-        enc = {'dtype': 'float64',
+        enc = {'dtype': 'int64',
                'zlib': True,
                'units': 'milliseconds since 1970-01-01',
                'complevel': 4,

--- a/level1c4pps/tests/test_eumgacfdr2pps.py
+++ b/level1c4pps/tests/test_eumgacfdr2pps.py
@@ -81,8 +81,8 @@ class TestEumgacfdr2PPS(unittest.TestCase):
                        'add_offset': 273.15},
             'qual_flags':  {'dtype': 'int16', 'zlib': True,
                             'complevel': 4, '_FillValue': -32001.0},
-            'scanline_timestamps': {'dtype': 'int64', 'zlib': True,
-                                    'units': 'Milliseconds since 1970-01-01',
+            'scanline_timestamps': {'dtype': 'float64', 'zlib': True,
+                                    'units': 'milliseconds since 1970-01-01',
                                     'complevel': 4, '_FillValue': -1.0},
         }
         encoding = eumgacfdr2pps.get_encoding_gac(self.scene)

--- a/level1c4pps/tests/test_eumgacfdr2pps.py
+++ b/level1c4pps/tests/test_eumgacfdr2pps.py
@@ -81,7 +81,7 @@ class TestEumgacfdr2PPS(unittest.TestCase):
                        'add_offset': 273.15},
             'qual_flags':  {'dtype': 'int16', 'zlib': True,
                             'complevel': 4, '_FillValue': -32001.0},
-            'scanline_timestamps': {'dtype': 'float64', 'zlib': True,
+            'scanline_timestamps': {'dtype': 'int64', 'zlib': True,
                                     'units': 'milliseconds since 1970-01-01',
                                     'complevel': 4, '_FillValue': -1.0},
         }

--- a/level1c4pps/tests/test_gac2pps.py
+++ b/level1c4pps/tests/test_gac2pps.py
@@ -80,7 +80,7 @@ class TestGac2PPS(unittest.TestCase):
                        'add_offset': 273.15},
             'qual_flags':  {'dtype': 'int16', 'zlib': True,
                             'complevel': 4, '_FillValue': -32001.0},
-            'scanline_timestamps': {'dtype': 'float64', 'zlib': True,
+            'scanline_timestamps': {'dtype': 'int64', 'zlib': True,
                                     'units': 'milliseconds since 1970-01-01',
                                     'complevel': 4, '_FillValue': -1.0},
         }

--- a/level1c4pps/tests/test_gac2pps.py
+++ b/level1c4pps/tests/test_gac2pps.py
@@ -80,8 +80,8 @@ class TestGac2PPS(unittest.TestCase):
                        'add_offset': 273.15},
             'qual_flags':  {'dtype': 'int16', 'zlib': True,
                             'complevel': 4, '_FillValue': -32001.0},
-            'scanline_timestamps': {'dtype': 'int64', 'zlib': True,
-                                    'units': 'Milliseconds since 1970-01-01',
+            'scanline_timestamps': {'dtype': 'float64', 'zlib': True,
+                                    'units': 'milliseconds since 1970-01-01',
                                     'complevel': 4, '_FillValue': -1.0},
         }
         encoding = gac2pps.get_encoding_gac(self.scene)

--- a/level1c4pps/tests/test_vgac2pps.py
+++ b/level1c4pps/tests/test_vgac2pps.py
@@ -80,7 +80,7 @@ class TestVgac2PPS(unittest.TestCase):
                        'add_offset': 273.15},
             'qual_flags':  {'dtype': 'int16', 'zlib': True,
                             'complevel': 4, '_FillValue': -32001.0},
-            'scanline_timestamps': {'dtype': 'float64',
+            'scanline_timestamps': {'dtype': 'int64',
                                     'zlib': True,
                                     'units': 'milliseconds since 1970-01-01',
                                     'complevel': 4,

--- a/level1c4pps/tests/test_vgac2pps.py
+++ b/level1c4pps/tests/test_vgac2pps.py
@@ -123,7 +123,10 @@ class TestVgac2PPS(unittest.TestCase):
 
         np.testing.assert_almost_equal(pps_nc.variables['image1'].sun_earth_distance_correction_factor,
                                        1.0, decimal=4)
-        assert pps_nc.variables["scanline_timestamps"].units == 'milliseconds since 1970-01-01' 
+        assert (
+            pps_nc.variables["scanline_timestamps"].units == "milliseconds since 1970-01-01"
+            and pps_nc.variables["scanline_timestamps"].dtype == "int"
+        )
 
     def test_process_one_scene_n19(self):
         """Test process one scene for one example file."""

--- a/level1c4pps/tests/test_vgac2pps.py
+++ b/level1c4pps/tests/test_vgac2pps.py
@@ -80,9 +80,16 @@ class TestVgac2PPS(unittest.TestCase):
                        'add_offset': 273.15},
             'qual_flags':  {'dtype': 'int16', 'zlib': True,
                             'complevel': 4, '_FillValue': -32001.0},
-            'scanline_timestamps': {'dtype': 'int64', 'zlib': True,
-                                    'units': 'Milliseconds since 1970-01-01',
-                                    'complevel': 4, '_FillValue': -1.0},
+            'scanline_timestamps': {'dtype': 'float',
+                                    'zlib': True,
+                                    'units': 'milliseconds since 1970-01-01',
+                                    'complevel': 4,
+                                    '_FillValue': -1.0},
+            'time': {'dtype': 'float',
+                     'zlib': True,
+                     'units': 'milliseconds since 1970-01-01',
+                     'complevel': 4,
+                     '_FillValue': -1.0},
         }
         encoding = vgac2pps.get_encoding_viirs(self.scene)
         self.assertDictEqual(encoding, encoding_exp)
@@ -121,6 +128,7 @@ class TestVgac2PPS(unittest.TestCase):
 
         np.testing.assert_almost_equal(pps_nc.variables['image1'].sun_earth_distance_correction_factor,
                                        1.0, decimal=4)
+        assert pps_nc.variables["scanline_timestamps"].units == 'milliseconds since 1970-01-01' 
 
     def test_process_one_scene_n19(self):
         """Test process one scene for one example file."""

--- a/level1c4pps/tests/test_vgac2pps.py
+++ b/level1c4pps/tests/test_vgac2pps.py
@@ -80,16 +80,11 @@ class TestVgac2PPS(unittest.TestCase):
                        'add_offset': 273.15},
             'qual_flags':  {'dtype': 'int16', 'zlib': True,
                             'complevel': 4, '_FillValue': -32001.0},
-            'scanline_timestamps': {'dtype': 'float',
+            'scanline_timestamps': {'dtype': 'float64',
                                     'zlib': True,
                                     'units': 'milliseconds since 1970-01-01',
                                     'complevel': 4,
                                     '_FillValue': -1.0},
-            'time': {'dtype': 'float',
-                     'zlib': True,
-                     'units': 'milliseconds since 1970-01-01',
-                     'complevel': 4,
-                     '_FillValue': -1.0},
         }
         encoding = vgac2pps.get_encoding_viirs(self.scene)
         self.assertDictEqual(encoding, encoding_exp)

--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -357,10 +357,11 @@ def convert_to_noaa19(scene, sbaf_version):
 
 def get_encoding_viirs(scene):
     """Get netcdf encoding for all datasets."""
-    return get_encoding(scene,
-                        BANDNAMES,
-                        PPS_TAGNAMES,
-                        chunks=None)
+    encoding = get_encoding(scene, BANDNAMES, PPS_TAGNAMES, chunks=None)
+    encoding["scanline_timestamps"]["dtype"] = "float"
+    encoding["scanline_timestamps"]["units"] = "milliseconds since 1970-01-01"
+    encoding["time"] = encoding["scanline_timestamps"]
+    return encoding
 
 
 def set_header_and_band_attrs(scene, orbit_n=0):

--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -357,11 +357,10 @@ def convert_to_noaa19(scene, sbaf_version):
 
 def get_encoding_viirs(scene):
     """Get netcdf encoding for all datasets."""
-    encoding = get_encoding(scene, BANDNAMES, PPS_TAGNAMES, chunks=None)
-    encoding["scanline_timestamps"]["dtype"] = "float"
-    encoding["scanline_timestamps"]["units"] = "milliseconds since 1970-01-01"
-    encoding["time"] = encoding["scanline_timestamps"]
-    return encoding
+    return get_encoding(scene,
+                        BANDNAMES,
+                        PPS_TAGNAMES,
+                        chunks=None)
 
 
 def set_header_and_band_attrs(scene, orbit_n=0):

--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -456,6 +456,13 @@ def split_scene_at_midnight(scene):
     return [scene]
 
 
+def fix_timestamp_datatype(scene, encoding):
+    """Fix time datatype."""
+    param = "scanline_timestamps"
+    if "milliseconds" in encoding[param]["units"]:
+        scene[param].data = scene[param].data.astype('datetime64[ms]')
+
+
 def process_one_scene(scene_files, out_path, engine="h5netcdf",
                       all_channels=False, pps_channels=False, orbit_n=0,
                       noaa19_sbaf_version=None, avhrr_channels=False,
@@ -506,6 +513,7 @@ def process_one_scene(scene_files, out_path, engine="h5netcdf",
 
         filename = compose_filename(scn_, out_path, instrument=sensor, band=irch)
         encoding = get_encoding_viirs(scn_)
+        fix_timestamp_datatype(scn_, encoding)
 
         scn_.save_datasets(writer="cf",
                            filename=filename,


### PR DESCRIPTION
This PR deals with https://github.com/foua-pps/level1c4pps/issues/93
and makes that time unit is `milliseconds since 1970-01-01` and  in vgac files.


 - [x] Closes https://github.com/foua-pps/level1c4pps/issues/93
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
