### PR TITLE
Add fix for sun_earth_distance_correction_factor

### DIFF
--- a/bin/seviri2pps.py
+++ b/bin/seviri2pps.py
@@ -56,9 +56,6 @@ if __name__ == "__main__":
                         help="Engine for saving netcdf files netcdf4 or h5netcdf (default).")
     parser.add_argument('--use-nominal-time-in-filename', action='store_true',
                         help='Use nominal scan timestamps in output filename.')
-    parser.add_argument('--no-sun-earth-distance-correction',
-                        action='store_true',
-                        help='Do not apply sun earth distance correction.')
     options = parser.parse_args()
     process_one_scan(
         options.files,

--- a/bin/seviri2pps.py
+++ b/bin/seviri2pps.py
@@ -63,6 +63,5 @@ if __name__ == "__main__":
         rotate=not options.no_rotation,
         engine=options.nc_engine,
         use_nominal_time_in_filename=options.use_nominal_time_in_filename,
-        apply_sun_earth_distance_correction=not options.no_sun_earth_distance_correction,
         save_azimuth_angles=options.azimuth_angles,
     )

--- a/level1c4pps/seviri2pps_lib.py
+++ b/level1c4pps/seviri2pps_lib.py
@@ -44,7 +44,11 @@ from pyorbital.astronomy import get_alt_az, sun_zenith_angle
 from pyorbital.orbital import get_observer_look
 
 from level1c4pps.calibration_coefs import get_calibration, CalibrationData
-from level1c4pps import make_azidiff_angle, get_encoding, compose_filename, update_angle_attributes
+from level1c4pps import (make_azidiff_angle,
+                         get_encoding,
+                         compose_filename,
+                         update_angle_attributes,
+                         fix_sun_earth_distance_correction_factor)
 
 
 try:
@@ -274,10 +278,15 @@ def set_attrs(scene):
         scene[band].attrs['wavelength'] = [scene[band].attrs['wavelength'].min,
                                            scene[band].attrs['wavelength'].central,
                                            scene[band].attrs['wavelength'].max]
+
         if 'sun_earth_distance_correction_factor' not in scene[band].attrs:
             scene[band].attrs['sun_earth_distance_correction_applied'] = False
             scene[band].attrs['sun_earth_distance_correction_factor'] = 1.0
+        else:
+            fix_sun_earth_distance_correction_factor(scene, band, scene[band].attrs['start_time'])
+            
         scene[band].attrs['sun_zenith_angle_correction_applied'] = False
+        
         scene[band].attrs['name'] = "image{:d}".format(image_num)
 
         # Cosmetics

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -81,8 +81,8 @@ class TestSeviri2PPS(unittest.TestCase):
 
         # Compare results and expectations
         vis006_exp = xr.DataArray(
-            [[1.0, 2.0],
-             [3.0, 4.0]],
+            [[1.034205, 2.06841],
+             [3.102615, 4.13682]],
             dims=('y', 'x')
         )
         ir_108_exp = xr.DataArray(
@@ -90,9 +90,12 @@ class TestSeviri2PPS(unittest.TestCase):
              [7, 8]],
             dims=('y', 'x')
         )
+        from satpy.readers.utils import remove_earthsun_distance_correction
+        res['VIS006'] = remove_earthsun_distance_correction(res['VIS006'])
         xr.testing.assert_allclose(res['VIS006'], vis006_exp)
         xr.testing.assert_equal(res['IR_108'], ir_108_exp)
-        self.assertTrue(
+        
+        self.assertFalse(
             res['VIS006'].attrs['sun_earth_distance_correction_applied'],
         )
 

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -75,15 +75,14 @@ class TestSeviri2PPS(unittest.TestCase):
         filenames = ['MSG4-SEVI-MSG15-1234-NA-20190409121243.927000000Z']
         res = seviri2pps.load_and_calibrate(
             filenames,
-            apply_sun_earth_distance_correction=False,
             rotate=False,
             clip_calib=False
         )
 
         # Compare results and expectations
         vis006_exp = xr.DataArray(
-            [[1.034205, 2.06841],
-             [3.102615, 4.13682]],
+            [[1.0, 2.0],
+             [3.0, 4.0]],
             dims=('y', 'x')
         )
         ir_108_exp = xr.DataArray(
@@ -91,10 +90,9 @@ class TestSeviri2PPS(unittest.TestCase):
              [7, 8]],
             dims=('y', 'x')
         )
-        res['VIS006'].sun_earth_distance_correction_factor
         xr.testing.assert_allclose(res['VIS006'], vis006_exp)
         xr.testing.assert_equal(res['IR_108'], ir_108_exp)
-        self.assertFalse(
+        self.assertTrue(
             res['VIS006'].attrs['sun_earth_distance_correction_applied'],
         )
 
@@ -106,7 +104,6 @@ class TestSeviri2PPS(unittest.TestCase):
         filenames = ['MSG4-SEVI-MSG15-1234-NA-20190409121243.927000000Z']
         res = seviri2pps.load_and_calibrate(
             filenames,
-            apply_sun_earth_distance_correction=False,
             rotate=True,
             clip_calib=False
         )

--- a/level1c4pps/tests/test_seviri2pps.py
+++ b/level1c4pps/tests/test_seviri2pps.py
@@ -81,11 +81,6 @@ class TestSeviri2PPS(unittest.TestCase):
         )
 
         # Compare results and expectations
-        vis006_exp_pyspectral_1_7_1 = xr.DataArray(
-            [[1.07025268, 2.14050537],
-             [3.21075805, 4.28101074]],
-            dims=('y', 'x')
-        )
         vis006_exp = xr.DataArray(
             [[1.034205, 2.06841],
              [3.102615, 4.13682]],
@@ -96,11 +91,8 @@ class TestSeviri2PPS(unittest.TestCase):
              [7, 8]],
             dims=('y', 'x')
         )
-        if res['VIS006'][0, 0] > 1.04:
-            # pyspectral 1.7.1 and older
-            xr.testing.assert_allclose(res['VIS006'], vis006_exp_pyspectral_1_7_1)
-        else:
-            xr.testing.assert_allclose(res['VIS006'], vis006_exp)
+        res['VIS006'].sun_earth_distance_correction_factor
+        xr.testing.assert_allclose(res['VIS006'], vis006_exp)
         xr.testing.assert_equal(res['IR_108'], ir_108_exp)
         self.assertFalse(
             res['VIS006'].attrs['sun_earth_distance_correction_applied'],
@@ -211,15 +203,14 @@ class TestSeviri2PPS(unittest.TestCase):
     def test_set_attrs(self):
         """Test setting scene attributes."""
         seviri2pps.BANDNAMES = ['VIS006', 'IR_108']
-        vis006 = mock.MagicMock(attrs={'wavelength': WavelengthRange(0.56, 0.635, 0.71)})
-        ir108 = mock.MagicMock(attrs={'platform_name': 'myplatform',
-                                      'wavelength': WavelengthRange(9.8, 10.8, 11.8),
-                                      'orbital_parameters': {'orb_a': 1,
-                                                             'orb_b': 2},
-                                      'georef_offset_corrected': True})
-        scene_dict = {'VIS006': vis006, 'IR_108': ir108}
-        scene = mock.MagicMock(attrs={})
-        scene.__getitem__.side_effect = scene_dict.__getitem__
+        scene = get_fake_scene()
+        scene['VIS006'].attrs['sun_earth_distance_correction_applied'] = True
+        scene['VIS006'].attrs['start_time'] = dt.datetime(2020, 1, 1, 12)
+        scene['VIS006'].attrs['sun_earth_distance_correction_factor'] = 0.9833241577909706
+        scene['IR_108'].attrs['orbital_parameters'] = {'orb_a': 1,
+                                                       'orb_b': 2}
+        scene['IR_108'].attrs['georef_offset_corrected'] =  True
+        scene['IR_108'].attrs['platform_name'] = "my_platform_name"
 
         seviri2pps.set_attrs(scene)
         self.assertEqual(scene['VIS006'].attrs['name'], 'image0')
@@ -229,7 +220,18 @@ class TestSeviri2PPS(unittest.TestCase):
         self.assertNotIn('orb_a', scene.attrs)
         self.assertNotIn('orbital_parameters', scene.attrs)
         self.assertNotIn('georef_offset_corrected', scene.attrs)
+        exp_sun_earth_distance_correction_factor = 0.9669263992953216
+        sun_earth_distance = 0.9833241577909706
+        self.assertAlmostEqual(scene['VIS006'].sun_earth_distance_correction_factor,
+                               exp_sun_earth_distance_correction_factor, places=7)
+        self.assertAlmostEqual(scene['VIS006'].pps_sun_earth_distance_correction_factor,
+                               exp_sun_earth_distance_correction_factor, places=7)
+        self.assertAlmostEqual(scene['VIS006'].satpy_sun_earth_distance_correction_factor,
+                               sun_earth_distance, places=7)
+        self.assertAlmostEqual(scene['VIS006'].sun_earth_distance,
+                               sun_earth_distance, places=7)
 
+             
     def test_get_mean_acq_time(self):
         """Test computation of mean scanline acquisition time."""
         seviri2pps.BANDNAMES = ['VIS006', 'IR_108']


### PR DESCRIPTION
The history of the sun earth distance correction is in pygac/satpy and pyorbital. With some combination of satpy and pyorbital (2020-2022) the correction where in practice applied twice. And since 2022 the attribute sun_earth_distance_correction_factor from satpy no longer includes the factor for correction but sqrt(the original correction).

The history of the correction in pytroll:

Original formula in pygac and pyorbital from 2014: corr_ = 1 - 0.0334 * np.cos(2 * np.pi * (jdays2000(utc_time) - 2) / year)

Calulcated in pygac and applied like refl = refl * corr_. With attribute set in pygac: sun_earth_distance_correction_factor = corr_

2020-06 Pygac correction depricated.
2020-09 Satpy reads corrrection from pyorbital but applies like refl = refl * corr_ * corr_ causing the correction to be applied twice.
2020-09 Attribute set in satpy: sun_earth_distance_correction_factor = corr_, same as before.

2022-06 Pyorbital correction in principle replaced with sqrt(corr_). This implies reflections now corrected with refl = refl * corr_ in satpy as expected. The sun_earth_distance_correction_factor attribute in principle set to np.sqrt(corr_)
 which means the attribute no longer contain the original sun_earth_distance_correction_factor attribute.

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
