### PR TITLE
Fix VGAC sun earth distance applied attribute

### DIFF
--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -563,8 +563,9 @@ def set_header_and_band_attrs(scene, orbit_n=0):
     for band in REFL_BANDS:
         if band not in scene:
             continue
-        # For VIIRS data sun_zenith_angle_correction_applied is applied always!
+        # Original VGAC files provide normalized reflectances AND Earth-Sun distance corrected data
         scene[band].attrs["sun_zenith_angle_correction_applied"] = "True"
+        scene[band].attrs['sun_earth_distance_correction_applied'] = "True"
     return nimg
 
 


### PR DESCRIPTION
Original VGAC files provide normalized reflectances AND Earth-Sun distance corrected data

<!-- Describe what your PR does, and why -->

 - [x] Closes #94 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
