### PR TITLE
better dependecy handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ install_requires = [
     "satpy[avhrr_l1b_eps,viirs_l1b,viirs_sdr,viirs_compact]!=0.38.*,!=0.39.*,!=0.40.*,!=0.41.*",
 ]
 extras_requires = {
-    "extra": "satpy[avhrr_l1b_gaclac,seviri_l1b_hrit,seviri_l1b_native,seviri_l1b_nc,vii_l1b_nc]"
+     "gaclac": "satpy[avhrr_l1b_gaclac]",
+     "seviri": "satpy[seviri_l1b_hrit,seviri_l1b_native,seviri_l1b_nc]",
 }
 NAME = "level1c4pps"
 README = open('README.md', 'r').read()

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,16 @@ except ImportError:
     pass
 
 
-requires = ['satpy!=0.38.*,!=0.39.*,!=0.40.*,!=0.41.*', 'pyorbital', 'trollsift', 'pyspectral', 'h5netcdf']
-
-
+install_requires = [
+    "h5netcdf",
+    "pyorbital",
+    "pyspectral",
+    "trollsift",
+    "satpy[avhrr_l1b_eps,viirs_l1b,viirs_sdr,viirs_compact]!=0.38.*,!=0.39.*,!=0.40.*,!=0.41.*",
+]
+extras_requires = {
+    "extra": "satpy[avhrr_l1b_gaclac,seviri_l1b_hrit,seviri_l1b_native,seviri_l1b_nc,vii_l1b_nc]"
+}
 NAME = "level1c4pps"
 README = open('README.md', 'r').read()
 
@@ -68,6 +75,7 @@ setup(name=NAME,
       zip_safe=False,
       use_scm_version=True,
       python_requires='>=3.7',
-      install_requires=requires,
+      install_requires=install_requires,
+      extras_require=extras_requires,
       test_suite='level1c4pps.tests.suite',
       )


### PR DESCRIPTION
This PR improves the dependency handling.

If you install the package by `pip install .` only some default packages will be installed needed for the most important script of the `level1c4pps` package. 

If you install it by `pip install .[extra]` you will install some additional packages needed for some specific `satpy` readers.

I am not totally sure which readers that should installed by default, so comments are welcome. 

Note that `level1c4pps` utilises more readers than it looks like in the modified `setup.py` file as we only need to specify the readers that requires a non default `satpy` installation.  