### PR TITLE
Fix sunz normalization for viirs_compact

### DIFF
--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -437,6 +437,8 @@ def set_header_and_band_attrs_defaults(scene, BANDNAMES, PPS_TAGNAMES, REFL_BAND
             fix_sun_earth_distance_correction_factor(scene, band, irch.attrs['start_time'])
         scene[band].attrs['wavelength'] = scene[band].attrs['wavelength'][0:3]
         scene[band].attrs['sun_zenith_angle_correction_applied'] = 'False'
+        if "sunz_corrected" in scene[band].attrs.get('modifiers', []):
+            scene[band].attrs['sun_zenith_angle_correction_applied'] = 'True'
         if idtag in PPS_TAGNAMES_TO_IMAGE_NR:
             scene[band].attrs['name'] = PPS_TAGNAMES_TO_IMAGE_NR[idtag]
         else:

--- a/level1c4pps/tests/test_viirs2pps.py
+++ b/level1c4pps/tests/test_viirs2pps.py
@@ -37,6 +37,7 @@ class TestViirs2PPS(unittest.TestCase):
         """Create a test scene."""
         viirs2pps.BANDNAMES = ['M05', 'M15']
         vis006 = mock.MagicMock(attrs={'name': 'image0',
+                                       'modifiers': ("sunz_correction", ),
                                        'wavelength': [1, 2, 3, 'um'],
                                        'id_tag': 'ch_r06'})
         ir_108 = mock.MagicMock(attrs={

--- a/level1c4pps/viirs2pps_lib.py
+++ b/level1c4pps/viirs2pps_lib.py
@@ -150,7 +150,7 @@ def process_one_scene(scene_files, out_path, use_iband_res=False, reader='viirs_
     elif reader == "viirs_compact":
         scn_.load(MY_MBAND_TB + ANGLE_NAMES + ['latitude_m', 'longitude_m'], resolution=742)
         # Load reflective bands with sunz-correction (not the default for VIIRS compact).
-        scn_.load(MY_MBAND_REFL, modifiers="sunz_corrected")
+        scn_.load(MY_MBAND_REFL, modifiers=("sunz_corrected", ))
     else:
         scn_.load(MY_MBAND + ANGLE_NAMES + ['m_latitude', 'm_longitude'], resolution=742)
 

--- a/level1c4pps/viirs2pps_lib.py
+++ b/level1c4pps/viirs2pps_lib.py
@@ -114,11 +114,8 @@ def set_header_and_band_attrs(scene, orbit_n=0):
     for band in REFL_BANDS:
         if band not in scene:
             continue
-        # SDR has data has sun_zenith_angle_correction_applied, viirs_compact does not!
-        # We now read data with the sunz_corrected modifier
+        # VIIRS data read with sunz_corrected modifier
         scene[band].attrs['sun_zenith_angle_correction_applied'] = 'True'
-        if "sunz_corrected" not in scene['M05'].attrs['modifiers']:
-            logger.exception(f"Data is not sunz_corrected!")
     return nimg
 
 
@@ -152,8 +149,8 @@ def process_one_scene(scene_files, out_path, use_iband_res=False, reader='viirs_
         scn_ = scn_.resample(resampler='native')
     elif reader == "viirs_compact":
         scn_.load(MY_MBAND_TB + ANGLE_NAMES + ['latitude_m', 'longitude_m'], resolution=742)
+        # Load reflective bands with sunz-correction (not the default for VIIRS compact).
         scn_.load(MY_MBAND_REFL, modifiers="sunz_corrected")
-
     else:
         scn_.load(MY_MBAND + ANGLE_NAMES + ['m_latitude', 'm_longitude'], resolution=742)
 


### PR DESCRIPTION
SDR data has sun_zenith_angle_correction_applied as default, viirs_compact does not! We now read data with the sunz_corrected modifier and satpy applyes the normalization. Note that reflective bands are
 read separately to avoid sunz_correction applied to the IR channels.

<!-- Describe what your PR does, and why -->

 - [x] Closes #107
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [x] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
