### PR TITLE
Fix platform names for NOAA20 and NOAA21

### DIFF
--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -542,6 +542,7 @@ def platform_name_to_use_in_filename(platform_name):
     replace_dict = {'aqua': '2',
                     '-': '',
                     'jpss1': 'noaa20',
+                    'jpss2': 'noaa21',
                     'terra': '1',
                     'suomi': ''}
     for orig, new in replace_dict.items():

--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -782,6 +782,12 @@ def fix_timestamp_datatype(scene, encoding):
     if "milliseconds" in encoding[param]["units"]:
         scene[param].data = scene[param].data.astype('datetime64[ms]')
 
+def fix_platform_name(scene, scene_files):
+    """For some NOAA20/NOAA21 production the platform name in the global attribute is set to Suomi-NPP."""
+    if "VGAC_VN20" in os.path.basename(scene_files[0]):
+        scene.attrs['platform'] = "JPSS-1"
+    if "VGAC_VN21" in os.path.basename(scene_files[0]):
+        scene.attrs['platform'] = "JPSS-2"
 
 def process_one_scene(scene_files, out_path, engine="h5netcdf",
                       all_channels=False, pps_channels=False, orbit_n=0,
@@ -807,6 +813,7 @@ def process_one_scene(scene_files, out_path, engine="h5netcdf",
     scn_in.load(MY_MBAND
                 + ANGLE_NAMES
                 + ["latitude", "longitude", "scanline_timestamps"])
+    fix_platform_name(scn_in, scene_files)
     if split_files_at_midnight:
         scenes = split_scene_at_midnight(scn_in)
     else:


### PR DESCRIPTION
The platform name in the global attributes of the files, are for the filetype VGAC_VN2002MOD_A2019360_1620_n10901_K005.nc set to Suomi-NPP. And from the filename it should be NOAA-20. 

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Add your name to `AUTHORS.md` if not there already