### PR TITLE
Handle satpy appending while writing

### DIFF
--- a/level1c4pps/avhrr2pps_lib.py
+++ b/level1c4pps/avhrr2pps_lib.py
@@ -119,13 +119,15 @@ def process_one_scene(scene_files, out_path, engine='h5netcdf', orbit_n=0):
     apply_sunz_correction(scn_, REFL_BANDS)
 
     filename = compose_filename(scn_, out_path, instrument='avhrr', band=irch)
+    tmp_filename = filename.replace("Z.nc", "Z_temp.nc")
     scn_.save_datasets(writer='cf',
-                       filename=filename,
+                       filename=tmp_filename,
                        header_attrs=get_header_attrs(scn_, band=irch, sensor='avhrr'),
                        engine=engine,
                        include_lonlats=False,
                        flatten_attrs=True,
                        encoding=get_encoding_avhrr(scn_))
+    os.rename(tmp_filename, filename)
     print("Saved file {:s} after {:3.1f} seconds".format(
         os.path.basename(filename),
         time.time() - tic))

--- a/level1c4pps/metimage2pps_lib.py
+++ b/level1c4pps/metimage2pps_lib.py
@@ -171,13 +171,15 @@ def process_one_scene(scene_files, out_path,
     # apply_sunz_correction(scn_, REFL_BANDS)
 
     filename = compose_filename(scn_, out_path, instrument='metimage', band=irch)
+    tmp_filename = filename.replace("Z.nc", "Z_temp.nc")
     scn_.save_datasets(writer='cf',
-                       filename=filename,
+                       filename=tmp_filename,
                        header_attrs=get_header_attrs(scn_, band=irch, sensor='metimage'),
                        engine=engine,
                        include_lonlats=False,
                        flatten_attrs=True,
                        encoding=get_encoding_metimage(scn_))
+    os.rename(tmp_filename, filename)
     print("Saved file {:s} after {:3.1f} seconds".format(
         os.path.basename(filename),
         time.time() - tic))

--- a/level1c4pps/modis2pps_lib.py
+++ b/level1c4pps/modis2pps_lib.py
@@ -143,13 +143,15 @@ def process_one_scene(scene_files, out_path, engine='h5netcdf', all_channels=Fal
     apply_sunz_correction(scn_, REFL_BANDS)
 
     filename = compose_filename(scn_, out_path, instrument='modis', band=irch)
+    tmp_filename = filename.replace("Z.nc", "Z_temp.nz")
     scn_.save_datasets(writer='cf',
-                       filename=filename,
+                       filename=tmp_filename,
                        header_attrs=get_header_attrs(scn_, band=irch, sensor='modis'),
                        engine=engine,
                        include_lonlats=False,
                        flatten_attrs=True,
                        encoding=get_encoding_modis(scn_))
+    os.rename(tmp_filename, filename)
     print("Saved file {:s} after {:3.1f} seconds".format(
         os.path.basename(filename),
         time.time() - tic))

--- a/level1c4pps/viirs2pps_lib.py
+++ b/level1c4pps/viirs2pps_lib.py
@@ -168,13 +168,15 @@ def process_one_scene(scene_files, out_path, use_iband_res=False, reader='viirs_
     update_angle_attributes(scn_, irch)
 
     filename = compose_filename(scn_, out_path, instrument='viirs', band=irch)
+    tmp_filename = filename.replace("Z.nc", "Z_temp.nc")
     scn_.save_datasets(writer='cf',
-                       filename=filename,
+                       filename=tmp_filename,
                        header_attrs=get_header_attrs(scn_, band=irch, sensor='viirs'),
                        engine=engine,
                        include_lonlats=False,
                        flatten_attrs=True,
                        encoding=get_encoding_viirs(scn_))
+    os.rename(tmp_filename, filename)
     print("Saved file {:s} after {:3.1f} seconds".format(
         os.path.basename(filename),
         time.time() - tic))


### PR DESCRIPTION
Use temp file while file is appended. File is opened and appended several times. By using a temp file, it can be combined better with a pytroll-watcher.

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Add your name to `AUTHORS.md` if not there already