### PR TITLE
Add extra adjustment for noaa21

### DIFF
--- a/bin/vgac2pps.py
+++ b/bin/vgac2pps.py
@@ -43,6 +43,8 @@ if __name__ == "__main__":
                         default=None,
                         help=("Save only the AVHRR (1,2, 3B, 4, 5) channels to level1c4pps file. "
                               "And apply SBAFs to the channels. "))
+    parser.add_argument('--noaa21_to_snpp', default=None,
+                        help=("Apply SBAFs to the channels, can be combined with -n19. "))
     parser.add_argument('-pps_ch', '--pps_channels', action='store_true',
                         help="Save only the necessary (for PPS) channels to level1c4pps file.")
     parser.add_argument('-avhrr_ch', '--avhrr_channels', action='store_true',
@@ -56,5 +58,6 @@ if __name__ == "__main__":
     process_one_scene(options.files, options.out_dir, engine=options.nc_engine,
                       all_channels=options.all_channels, pps_channels=options.pps_channels,
                       orbit_n=options.orbit_number, noaa19_sbaf_version=options.as_noaa19,
+                      noaa21_sbaf_version=options.noaa21_to_snpp,
                       avhrr_channels=options.avhrr_channels,
                       split_files_at_midnight=not options.don_split_files_at_midnight)

--- a/bin/vgac2pps.py
+++ b/bin/vgac2pps.py
@@ -20,7 +20,8 @@
 """Script to convert VIIRS level-1 to PPS level-1c format using Pytroll/Satpy."""
 
 import argparse
-from level1c4pps.vgac2pps_lib import SBAF, process_one_scene
+import sys
+from level1c4pps.vgac2pps_lib import process_one_scene
 
 
 if __name__ == "__main__":
@@ -43,7 +44,7 @@ if __name__ == "__main__":
                         default=None,
                         help=("Save only the AVHRR (1,2, 3B, 4, 5) channels to level1c4pps file. "
                               "And apply SBAFs to the channels. "))
-    parser.add_argument('--noaa21_to_snpp', default=None, required="-n19",
+    parser.add_argument('--noaa21_to_snpp', default=None, required=("--as_noaa19" in sys.argv or "-n19" in sys.argv),
                         help=("Apply SBAFs to the channels, can be combined with -n19. "))
     parser.add_argument('-pps_ch', '--pps_channels', action='store_true',
                         help="Save only the necessary (for PPS) channels to level1c4pps file.")

--- a/bin/vgac2pps.py
+++ b/bin/vgac2pps.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
                         default=None,
                         help=("Save only the AVHRR (1,2, 3B, 4, 5) channels to level1c4pps file. "
                               "And apply SBAFs to the channels. "))
-    parser.add_argument('--noaa21_to_snpp', default=None,
+    parser.add_argument('--noaa21_to_snpp', default=None, required="-n19",
                         help=("Apply SBAFs to the channels, can be combined with -n19. "))
     parser.add_argument('-pps_ch', '--pps_channels', action='store_true',
                         help="Save only the necessary (for PPS) channels to level1c4pps file.")

--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -109,7 +109,7 @@ SBAF_N21_TO_SNPP = {
     }
     }
 SBAF_VGAC_SNPP_TO_N19 = {
-    
+
     "v2": {
         "r06": {
             "viirs_channel": "M05",
@@ -600,14 +600,17 @@ def convert_to_noaa19_neural_network(scene, sbaf_version):
 
     logger.info(f'Created NN version {sbaf_version}')
 
+
 def convert_to_noaa19_linear(scene, sbaf_version):
     """Apply linear sbafs to simulate noaa19 data."""
     convert_to_other_linear(scene, SBAF_VGAC_SNPP_TO_N19[sbaf_version])
 
+
 def convert_to_snpp_linear(scene, sbaf_version):
     """Apply linear sbafs to simulate SNPP data from NOAA21."""
     convert_to_other_linear(scene, SBAF_N21_TO_SNPP[sbaf_version])
-    
+
+
 def convert_to_other_linear(scene, SBAF):
     """Apply linear regression."""
     for avhhr_chan, scaling in SBAF.items():
@@ -682,7 +685,7 @@ def convert_to_noaa19(scene, sbaf_version, noaa21_sbaf_version):
     logger.info(f"Using SBAF_{sbaf_version}")
     if noaa21_sbaf_version is not None and scene.attrs["platform"] == "noaa21":
         convert_to_snpp_linear(scene, noaa21_sbaf_version)
-    if "NN" in sbaf_version:          
+    if "NN" in sbaf_version:
         convert_to_noaa19_neural_network(scene, sbaf_version)
     elif sbaf_version == "KNMI_v2":
         convert_to_noaa19_KNMI_v2(scene, sbaf_version)
@@ -806,6 +809,7 @@ def fix_platform_name(scene, scene_files):
         scene.attrs['platform'] = "JPSS-1"
     if "VGAC_VN21" in os.path.basename(scene_files[0]):
         scene.attrs['platform'] = "JPSS-2"
+
 
 def process_one_scene(scene_files, out_path, engine="h5netcdf",
                       all_channels=False, pps_channels=False, orbit_n=0,


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Add extra adjustment for NOAA21 before the NN-SBAFs.

Adjust NOAA21 to VIIRS, save as VIIRS:
vgac2pps.py VGAC_VN2102MOD_A2023365_0003_n05898_K005.nc --noaa21_to_snpp v1 (not possible any longer)

Adjust NOAA21 to VIIRS, than apply NN-SBAF and save as AVHRR:
vgac2pps.py VGAC_VN2102MOD_A2023365_0003_n05898_K005.nc --noaa21_to_snpp v1 -n19 NN_v4


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Add your name to `AUTHORS.md` if not there already