### PR TITLE
Adapt METimage to newer satpy

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
   - pyorbital
   - pytest
   - pytest-cov
+  - pytz
   - pip
   - pip:
     - trollsift

--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -536,6 +536,7 @@ def apply_sunz_correction(scene, REFL_BANDS):
         if band not in scene:
             continue
         if scene[band].attrs['sun_zenith_angle_correction_applied'] == 'False':
+            logger.info(f"Apply sunz correction for {band}")
             scene[band].values = scene[band].values * scaler
             scene[band].attrs['sun_zenith_angle_correction_applied'] = 'True'
 

--- a/level1c4pps/__init__.py
+++ b/level1c4pps/__init__.py
@@ -536,7 +536,7 @@ def apply_sunz_correction(scene, REFL_BANDS):
         if band not in scene:
             continue
         if scene[band].attrs['sun_zenith_angle_correction_applied'] == 'False':
-            logger.info(f"Apply sunz correction for {band}")
+            logger.info(f"Apply sunz zenith angle correction for {band}")
             scene[band].values = scene[band].values * scaler
             scene[band].attrs['sun_zenith_angle_correction_applied'] = 'True'
 

--- a/level1c4pps/metimage2pps_lib.py
+++ b/level1c4pps/metimage2pps_lib.py
@@ -48,7 +48,8 @@ logger = logging.getLogger('metimage2pps')
 if Version(satpy.__version__) <= Version('0.59.0'):
     logger.info("For METimage use satpy >= 0.60.")
     raise ValueError("For METimage satpy >= 0.60 is needed")
-
+else:
+    logger.info("Sunz correction not done by satpy reader for versions >= 0.60.")
 BANDNAMES_DEFAULT = ["vii_668",
                      "vii_865",
                      "vii_1375",
@@ -130,7 +131,7 @@ def set_header_and_band_attrs(scene, orbit_n=00000):
     for band in REFL_BANDS:
         if band not in scene:
             continue
-        logger.info("Sunz correction not done by satpy reader for versions >= 0.60.")
+        # Sunz correction not done by satpy reader for versions >= 0.60.
         scene[band].attrs['sun_zenith_angle_correction_applied'] = 'False'
     return nimg
 
@@ -164,7 +165,6 @@ def process_one_scene(scene_files, out_path,
 
     # one ir channel
     irch = scn_['vii_10690']
-
     set_header_and_band_attrs(scn_, orbit_n=orbit_n)
     rename_latitude_longitude(scn_)
     adjust_lons_to_valid_range(scn_)

--- a/level1c4pps/metimage2pps_lib.py
+++ b/level1c4pps/metimage2pps_lib.py
@@ -21,8 +21,10 @@
 
 import os
 import time
+import satpy
 from satpy.scene import Scene
-from level1c4pps import (get_encoding, compose_filename,
+from level1c4pps import (apply_sunz_correction,
+                         get_encoding, compose_filename,
                          rename_latitude_longitude,
                          update_angle_attributes, get_header_attrs,
                          set_header_and_band_attrs_defaults,
@@ -30,15 +32,22 @@ from level1c4pps import (get_encoding, compose_filename,
                          adjust_lons_to_valid_range)
 
 import logging
+from packaging.version import Version
+
 
 # from satpy.utils import debug_on
 # debug_on()
 
 # Example:
-# '/home/a001865/DATA_MISC/EPSSG_TEST/Testdata/W_xx-eumetsat-darmstadt,SAT,SGA1-VII-1B-RAD_C_EUMT_20191001043852_G_D_20070912095840_20070912100343_T_N____.nc'
+# W_xx-eumetsat-darmstadt,SAT,SGA1-VII-1B-RAD_C_EUMT_20191001043852_G_D_20070912095840_20070912100343_T_N____.nc'
+# W_XX-EUMETSAT-Darmstadt,SAT,SGA1-VII-1B-RAD_C_EUMT_20260211124622_G_V_20260211115100_20260211115158_C_N_T__.nc
 
 
 logger = logging.getLogger('metimage2pps')
+
+if Version(satpy.__version__) <= Version('0.59.0'):
+    logger.info("For METimage use satpy >= 0.60.")
+    raise ValueError("For METimage satpy >= 0.60 is needed")
 
 BANDNAMES_DEFAULT = ["vii_668",
                      "vii_865",
@@ -75,8 +84,8 @@ REFL_BANDS = ["vii_668", "vii_865", "vii_1375", "vii_1630", "vii_443",
               "vii_555", "vii_752", "vii_763", "vii_914", "vii_1240",
               "vii_2250"]
 
-ANGLE_NAMES = ['observation_zenith', 'solar_zenith',
-               'observation_azimuth', 'solar_azimuth']
+ANGLE_NAMES = ['satellite_zenith_angle', 'solar_zenith_angle',
+               'satellite_azimuth_angle', 'solar_azimuth_angle']
 
 PPS_TAGNAMES = {"vii_668": "ch_r06",
                 "vii_865": "ch_r09",
@@ -121,8 +130,8 @@ def set_header_and_band_attrs(scene, orbit_n=00000):
     for band in REFL_BANDS:
         if band not in scene:
             continue
-        print("Is this correct, it was in testdata3.")
-        scene[band].attrs['sun_zenith_angle_correction_applied'] = 'True'
+        logger.info("Sunz correction not done by satpy reader for versions >= 0.60.")
+        scene[band].attrs['sun_zenith_angle_correction_applied'] = 'False'
     return nimg
 
 
@@ -161,7 +170,7 @@ def process_one_scene(scene_files, out_path,
     adjust_lons_to_valid_range(scn_)
     convert_angles(scn_, delete_azimuth=True)
     update_angle_attributes(scn_, irch)
-    # apply_sunz_correction(scn_, REFL_BANDS)
+    apply_sunz_correction(scn_, REFL_BANDS)
     if platform_name is not None:
         scn_.attrs['platform'] = platform_name
     filename = compose_filename(scn_, out_path, instrument='metimage', band=irch)

--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -632,7 +632,6 @@ def convert_to_noaa19_neural_network(scene, sbaf_version):
         logger.exception(f"Unrecognized NN version, {sbaf_version}")
     scene = convert_to_vgac_with_nn(scene, day_cfg_file, night_cfg_file, twilight_cfg_file)
     if sbaf_version in ["NN_v4"]:
-        print(scene.attrs["platform"])
         # Postprocessing, extra SBAF for NOAA20 and NOAA21 needed due to differences compared to SNPP
         if scene.attrs["platform"] in ["noaa20", "noaa21"]:
             convert_to_other_linear(scene, SBAF_N19_TO_N19[sbaf_version][scene.attrs["platform"]])

--- a/level1c4pps/vgac2pps_lib.py
+++ b/level1c4pps/vgac2pps_lib.py
@@ -632,6 +632,7 @@ def convert_to_noaa19_neural_network(scene, sbaf_version):
         logger.exception(f"Unrecognized NN version, {sbaf_version}")
     scene = convert_to_vgac_with_nn(scene, day_cfg_file, night_cfg_file, twilight_cfg_file)
     if sbaf_version in ["NN_v4"]:
+        print(scene.attrs["platform"])
         # Postprocessing, extra SBAF for NOAA20 and NOAA21 needed due to differences compared to SNPP
         if scene.attrs["platform"] in ["noaa20", "noaa21"]:
             convert_to_other_linear(scene, SBAF_N19_TO_N19[sbaf_version][scene.attrs["platform"]])


### PR DESCRIPTION
Satpy 0.60 contains updates to the METimage reader. Sunz correction are no longer done, previously they were done twice. Older versions of satpy should not be used for METimage because of this double sunz correction

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed: Passes ``pytest level1c4pps`` <!-- for all non-documentation changes) -->
 - [ ] Passes ``flake8`` <!-- remove if you did not edit any Python files -->
 - [ ] Add your name to `AUTHORS.md` if not there already